### PR TITLE
Several cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,34 @@
 # System Transparency Tooling
-This repository contains scripts, configurations files and example date to form a build-, test- and development environment for *System Transparency*.
-The source code of the various components resides in the appropriate repositories. Detailed information about the project itself can be found at https://docs.system-transparency.org.
+
+This repository contains scripts, configurations files and example date to form a build-, test- and development environment for _System Transparency_.
+The source code of the various components resides in the appropriate repositories. Detailed information about the project itself can be found at https://system-transparency.org.
 
 Each folder contains an own README.md describing its content and the purpose of the files.
 
 ## Table of Content
-Directory | Description
------------- | -------------
-[`/`](README.md#scripts) | entry point
-[`configs/`](configs/README.md#configs) | configuration of operating systems
-[`deploy/`](deploy/README.md#deploy) | scripts and files to build firmware binaries
-[`deploy/coreboot-rom/`](deploy/coreboot-rom/README.md#deploy-coreboot-rom) | (work in progress)
-[`deploy/mixed-firmware/`](deploy/mixed-firmware/README.md#deploy-mixed-firmware) | disk image solution
-[`keys/`](keys/README.md#keys) | example certificates and signing keys
-[`operating-system/`](operating-system/README.md#operating-system) | folders including scripts ans files to build reprodu>
-[`operating-system/debian/`](operating-system/debian/README.md#operating-system-debian) | reproducible debian buster
-[`operating-system/debian/docker/`](operating-system/debian/docker/README.md#operating-system-debian-docker) | docker environment
-[`stboot/`](stboot/README.md#stboot) | scripts and files to build stboot bootloader from source
-[`stboot/include/`](stboot/include/README.md#stboot-include) | fieles to be includes into the bootloader's initramfs
-[`stboot/data/`](stboot/data/README.md#stboot-data) | fieles to be placed on a data partition of the host
-[`stconfig/`](stconfig/README.md#stconfig) | scripts and files to build the bootloader's configuration tool
+
+| Directory                                                                                           | Description                                                    |
+| --------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| [`/`](#scripts)                                                                                     | entry point                                                    |
+| [`configs/`](configs/#configs)                                                                      | configuration of operating systems                             |
+| [`deploy/`](deploy/#deploy)                                                                         | scripts and files to build firmware binaries                   |
+| [`deploy/coreboot-rom/`](deploy/coreboot-rom/#deploy-coreboot-rom)                                  | (work in progress)                                             |
+| [`deploy/mixed-firmware/`](deploy/mixed-firmware/#deploy-mixed-firmware)                            | disk image solution                                            |
+| [`keys/`](keys/#keys)                                                                               | example certificates and signing keys                          |
+| [`operating-system/`](operating-system/#operating-system)                                           | folders including scripts ans files to build reprodu>          |
+| [`operating-system/debian/`](operating-system/debian/#operating-system-debian)                      | reproducible debian buster                                     |
+| [`operating-system/debian/docker/`](operating-system/debian/docker/#operating-system-debian-docker) | docker environment                                             |
+| [`stboot/`](stboot/#stboot)                                                                         | scripts and files to build stboot bootloader from source       |
+| [`stboot/include/`](stboot/include/#stboot-include)                                                 | fieles to be includes into the bootloader's initramfs          |
+| [`stboot/data/`](stboot/data/#stboot-data)                                                          | fieles to be placed on a data partition of the host            |
+| [`stconfig/`](stconfig/#stconfig)                                                                   | scripts and files to build the bootloader's configuration tool |
 
 ## /
+
 ### Scripts
+
 #### `run.sh`
+
 This script is the global entry point to build up or update the environment.
 It runs a dependency check and prompts you to execute all other necessary scripts and thereby leads through the whole setup process. Each step can be run, run with special options where applicable or skipped. In this way you can also only renew certain parts of the environment.
 Run each step when executing for the first time. Some scripts need root privileges.
@@ -43,6 +48,6 @@ sudo update-alternatives --config gcc
 ```
 
 #### `start_qemu_mixed-firmware.sh`
-This script is invoked by `run.sh`. It will boot up *qemu* to test the system. All output is printed to the console.
-Use `ctrl+a` , `x` to terminate.
 
+This script is invoked by `run.sh`. It will boot up _qemu_ to test the system. All output is printed to the console.
+Use `ctrl+a` , `x` to terminate.

--- a/configs/README.md
+++ b/configs/README.md
@@ -1,22 +1,24 @@
 ## Table of Content
-Directory | Description
------------- | -------------
-[`/`](../README.md#scripts) | entry point
-[`configs/`](README.md#configs) | configuration of operating systems
-[`deploy/`](../deploy/README.md#deploy) | scripts and files to build firmware binaries
-[`deploy/coreboot-rom/`](../deploy/coreboot-rom/README.md#deploy-coreboot-rom) | (work in progress)
-[`deploy/mixed-firmware/`](../deploy/mixed-firmware/README.md#deploy-mixed-firmware) | disk image solution
-[`keys/`](../keys/README.md#keys) | example certificates and signing keys
-[`operating-system/`](../operating-system/README.md#operating-system) | folders including scripts ans files to build reprodu>
-[`operating-system/debian/`](../operating-system/debian/README.md#operating-system-debian) | reproducible debian buster
-[`operating-system/debian/docker/`](../operating-system/debian/docker/README.md#operating-system-debian-docker) | docker environment
-[`stboot/`](../stboot/README.md#stboot) | scripts and files to build stboot bootloader from source
-[`stboot/include/`](../stboot/include/README.md#stboot-include) | fieles to be includes into the bootloader's initramfs
-[`stboot/data/`](../stboot/data/README.md#stboot-data) | fieles to be placed on a data partition of the host
-[`stconfig/`](../stconfig/README.md#stconfig) | scripts and files to build the bootloader's configuration tool
+
+| Directory                                                                                              | Description                                                    |
+| ------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------- |
+| [`/`](../#scripts)                                                                                     | entry point                                                    |
+| [`configs/`](#configs)                                                                                 | configuration of operating systems                             |
+| [`deploy/`](../deploy/#deploy)                                                                         | scripts and files to build firmware binaries                   |
+| [`deploy/coreboot-rom/`](../deploy/coreboot-rom/#deploy-coreboot-rom)                                  | (work in progress)                                             |
+| [`deploy/mixed-firmware/`](../deploy/mixed-firmware/#deploy-mixed-firmware)                            | disk image solution                                            |
+| [`keys/`](../keys/#keys)                                                                               | example certificates and signing keys                          |
+| [`operating-system/`](../operating-system/#operating-system)                                           | folders including scripts ans files to build reprodu>          |
+| [`operating-system/debian/`](../operating-system/debian/#operating-system-debian)                      | reproducible debian buster                                     |
+| [`operating-system/debian/docker/`](../operating-system/debian/docker/#operating-system-debian-docker) | docker environment                                             |
+| [`stboot/`](../stboot/#stboot)                                                                         | scripts and files to build stboot bootloader from source       |
+| [`stboot/include/`](../stboot/include/#stboot-include)                                                 | fieles to be includes into the bootloader's initramfs          |
+| [`stboot/data/`](../stboot/data/#stboot-data)                                                          | fieles to be placed on a data partition of the host            |
+| [`stconfig/`](../stconfig/#stconfig)                                                                   | scripts and files to build the bootloader's configuration tool |
 
 ## Configs
-Directories for individual operating-system configuration can be created here. These directories must at least contain a 'stconfig.json' file. The corresponding files like OS-kernel, OS-initramfs, etc. can be included as well. After utilizing the *stconfig tool* 'stboot.ball' is saved there as well.
+
+Directories for individual operating-system configuration can be created here. These directories must at least contain a 'stconfig.json' file. The corresponding files like OS-kernel, OS-initramfs, etc. can be included as well. After utilizing the _stconfig tool_ 'stboot.ball' is saved there as well.
 See http://doc.system-transparency.org for further information about 'stconfig.json' and 'stboot.ball'
 
-The *debian* system included in this repository will create its configuration directory here automatically during the setup.
+The _debian_ system included in this repository will create its configuration directory here automatically during the setup.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,25 +1,28 @@
 ## Table of Content
-Directory | Description
------------- | -------------
-[`/`](../README.md#scripts) | entry point
-[`configs/`](../configs/README.md#configs) | configuration of operating systems
-[`deploy/`](README.md#deploy) | scripts and files to build firmware binaries
-[`deploy/coreboot-rom/`](coreboot-rom/README.md#deploy-coreboot-rom) | (work in progress)
-[`deploy/mixed-firmware/`](mixed-firmware/README.md#deploy-mixed-firmware) | disk image solution
-[`keys/`](../keys/README.md#keys) | example certificates and signing keys
-[`operating-system/`](../operating-system/README.md#operating-system) | folders including scripts ans files to build reprodu>
-[`operating-system/debian/`](../operating-system/debian/README.md#operating-system-debian) | reproducible debian buster
-[`operating-system/debian/docker/`](../operating-system/debian/docker/README.md#operating-system-debian-docker) | docker environment
-[`stboot/`](../stboot/README.md#stboot) | scripts and files to build stboot bootloader from source
-[`stboot/include/`](../stboot/include/README.md#stboot-include) | fieles to be includes into the bootloader's initramfs
-[`stboot/data/`](../stboot/data/README.md#stboot-data) | fieles to be placed on a data partition of the host
-[`stconfig/`](../stconfig/README.md#stconfig) | scripts and files to build the bootloader's configuration tool
+
+| Directory                                                                                              | Description                                                    |
+| ------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------- |
+| [`/`](../#scripts)                                                                                     | entry point                                                    |
+| [`configs/`](../configs/#configs)                                                                      | configuration of operating systems                             |
+| [`deploy/`](#deploy)                                                                                   | scripts and files to build firmware binaries                   |
+| [`deploy/coreboot-rom/`](coreboot-rom/#deploy-coreboot-rom)                                            | (work in progress)                                             |
+| [`deploy/mixed-firmware/`](mixed-firmware/#deploy-mixed-firmware)                                      | disk image solution                                            |
+| [`keys/`](../keys/#keys)                                                                               | example certificates and signing keys                          |
+| [`operating-system/`](../operating-system/#operating-system)                                           | folders including scripts ans files to build reprodu>          |
+| [`operating-system/debian/`](../operating-system/debian/#operating-system-debian)                      | reproducible debian buster                                     |
+| [`operating-system/debian/docker/`](../operating-system/debian/docker/#operating-system-debian-docker) | docker environment                                             |
+| [`stboot/`](../stboot/#stboot)                                                                         | scripts and files to build stboot bootloader from source       |
+| [`stboot/include/`](../stboot/include/#stboot-include)                                                 | fieles to be includes into the bootloader's initramfs          |
+| [`stboot/data/`](../stboot/data/#stboot-data)                                                          | fieles to be placed on a data partition of the host            |
+| [`stconfig/`](../stconfig/#stconfig)                                                                   | scripts and files to build the bootloader's configuration tool |
 
 ## Deploy
-The *stboot* boatloader can be deployed to a host in different ways. The sub directories here cover these solutions.
 
-Generally *stboot* is part of the host's firmware and comes as a flavor of *linuxboot*, more precisely as part of the *u-root* initrmfs inside *linuxboot*.
+The _stboot_ boatloader can be deployed to a host in different ways. The sub directories here cover these solutions.
+
+Generally _stboot_ is part of the host's firmware and comes as a flavor of _linuxboot_, more precisely as part of the _u-root_ initrmfs inside _linuxboot_.
 
 See also:
-* https://www.linuxboot.org/
-* https://github.com/u-root/u-root
+
+- https://www.linuxboot.org/
+- https://github.com/u-root/u-root

--- a/deploy/coreboot-rom/README.md
+++ b/deploy/coreboot-rom/README.md
@@ -1,26 +1,29 @@
 ## Table of Content
-Directory | Description
------------- | -------------
-[`/`](../../README.md#scripts) | entry point
-[`configs/`](../../configs/README.md#configs) | configuration of operating systems
-[`deploy/`](../README.md#deploy) | scripts and files to build firmware binaries
-[`deploy/coreboot-rom/`](README.md#deploy-coreboot-rom) | (work in progress)
-[`deploy/mixed-firmware/`](../mixed-firmware/README.md#deploy-mixed-firmware) | disk image solution
-[`keys/`](../../keys/README.md#keys) | example certificates and signing keys
-[`operating-system/`](../../operating-system/README.md#operating-system) | folders including scripts ans files to build reprodu>
-[`operating-system/debian/`](../../operating-system/debian/README.md#operating-system-debian) | reproducible debian buster
-[`operating-system/debian/docker/`](../../operating-system/debian/docker/README.md#operating-system-debian-docker) | docker environment
-[`stboot/`](../../stboot/README.md#stboot) | scripts and files to build stboot bootloader from source
-[`stboot/include/`](../../stboot/include/README.md#stboot-include) | fieles to be includes into the bootloader's initramfs
-[`stboot/data/`](../../stboot/data/README.md#stboot-data) | fieles to be placed on a data partition of the host
-[`stconfig/`](../../stconfig/README.md#stconfig) | scripts and files to build the bootloader's configuration tool
+
+| Directory                                                                                                 | Description                                                    |
+| --------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| [`/`](../../#scripts)                                                                                     | entry point                                                    |
+| [`configs/`](../../configs/#configs)                                                                      | configuration of operating systems                             |
+| [`deploy/`](../#deploy)                                                                                   | scripts and files to build firmware binaries                   |
+| [`deploy/coreboot-rom/`](#deploy-coreboot-rom)                                                            | (work in progress)                                             |
+| [`deploy/mixed-firmware/`](../mixed-firmware/#deploy-mixed-firmware)                                      | disk image solution                                            |
+| [`keys/`](../../keys/#keys)                                                                               | example certificates and signing keys                          |
+| [`operating-system/`](../../operating-system/#operating-system)                                           | folders including scripts ans files to build reprodu>          |
+| [`operating-system/debian/`](../../operating-system/debian/#operating-system-debian)                      | reproducible debian buster                                     |
+| [`operating-system/debian/docker/`](../../operating-system/debian/docker/#operating-system-debian-docker) | docker environment                                             |
+| [`stboot/`](../../stboot/#stboot)                                                                         | scripts and files to build stboot bootloader from source       |
+| [`stboot/include/`](../../stboot/include/#stboot-include)                                                 | fieles to be includes into the bootloader's initramfs          |
+| [`stboot/data/`](../../stboot/data/#stboot-data)                                                          | fieles to be placed on a data partition of the host            |
+| [`stconfig/`](../../stconfig/#stconfig)                                                                   | scripts and files to build the bootloader's configuration tool |
 
 ## Deploy Coreboot-ROM
+
 Work in progress ...
 
 This are some draft notes to build a coreboot image for the Supermicro X11SSH (only with system >=gcc-7)
 
 ### Build Coreboot
+
 ```
 sudo apt-get install -y bison build-essential curl flex git gnat libncurses5-dev m4 zlib1g-dev pkgconf libssl-dev uuid-dev
 git clone https://review.coreboot.org/coreboot
@@ -35,19 +38,26 @@ cp ../x11ssh-tf.defconfig .config
 git submodule update --checkout --init
 make -C util/ifdtool/
 ```
+
 ### Extract the vendor firmware from the X11SSH
+
 Use Flashrom from the coreboot repo (maybe install `libpci-dev`)
+
 ```
 cd ../
 https://review.coreboot.org/flashrom
 cd flashrom
 make
 ```
+
 Connect Flasher to the board and test cobbection a few times (ch341a_spi flasher is used here)
+
 ```
 sudo./flashrom -p ch341a_spi
 ```
+
 Read out the vendor firmware several times and check for read errors
+
 ```
 sudo ./flashrom -p ch341a_spi -r bios.1
 sudo ./flashrom -p ch341a_spi -r bios.2
@@ -55,10 +65,13 @@ sudo ./flashrom -p ch341a_spi -r bios.3
 diff bios.1 bios.2
 diff bios.1 bios.3
 ```
+
 Save the dumo as `original_vendor_bios_dump.bin` in the coreboot dir
 
 ### Build Coreboot continued
+
 Get ME and fd blob out of vendor firmware:
+
 ```
 ./util/ifdtool -x original_vendor_bios_dump.bin
 mkdir -p 3rdparty/blobs/mainboard/supermicro/x11-lga1151-series/
@@ -66,10 +79,11 @@ cp ../blobs/{me.bin,descriptor.bin} 3rdparty/blobs/mainboard/supermicro/x11-lga1
 make menuconfig
 BUILD_TIMELESS=1 make
 ```
+
 The coreboot image is in build/coreboot.rom
 LinuxBoot payload integration:
 Copy the linuxboot kernel and initramfs including stboot here (e.g from the mixed-firmware workflow)
-After running the tooling they are in 
+After running the tooling they are in
 `deploy/mixed-firmware/vmlinuz-linuxboot`
 `stboot/initramfs-linuxboot.cpio`
 
@@ -77,15 +91,19 @@ After running the tooling they are in
 gzip -9 initramfs.cpio
 ./build/cbfstool ./build/coreboot.rom add-payload -r COREBOOT -f kernel -n fallback/payload -C "console=ttyS0,115200 ro" -I initramfs.cpio.gz
 ```
+
 ### Flash X11SSH via bmc:
+
 Link to the tool: https://www.supermicro.com/en/solutions/management-software/ipmi-utilities
 At the bottom of the page you can download the SMCIPMITool.
+
 ```
 SMCIPMITool ip user pass bios update coreboot.rom -F -N -MER
 SMCIPMITool ip user pass ipmi power reset/up/down/staus
 ```
 
 ### Flash X11SSH manually (alternatively)
+
 ```
 sudo ./flashrom -p ch341a_spi --ifd -i bios -w ../coreboot/build/coreboot.rom
 ```

--- a/deploy/mixed-firmware/README.md
+++ b/deploy/mixed-firmware/README.md
@@ -1,75 +1,91 @@
 ## Table of Content
-Directory | Description
------------- | -------------
-[`/`](../../README.md#scripts) | entry point
-[`configs/`](../../configs/README.md#configs) | configuration of operating systems
-[`deploy/`](../README.md#deploy) | scripts and files to build firmware binaries
-[`deploy/coreboot-rom/`](../coreboot-rom/README.md#deploy-coreboot-rom) | (work in progress)
-[`deploy/mixed-firmware/`](README.md#deploy-mixed-firmware) | disk image solution
-[`keys/`](../../keys/README.md#keys) | example certificates and signing keys
-[`operating-system/`](../../operating-system/README.md#operating-system) | folders including scripts ans files to build reprodu>
-[`operating-system/debian/`](../../operating-system/debian/README.md#operating-system-debian) | reproducible debian buster
-[`operating-system/debian/docker/`](../../operating-system/debian/docker/README.md#operating-system-debian-docker) | docker environment
-[`stboot/`](../../stboot/README.md#stboot) | scripts and files to build stboot bootloader from source
-[`stboot/include/`](../../stboot/include/README.md#stboot-include) | fieles to be includes into the bootloader's initramfs
-[`stboot/data/`](../../stboot/data/README.md#stboot-data) | fieles to be placed on a data partition of the host
-[`stconfig/`](../../stconfig/README.md#stconfig) | scripts and files to build the bootloader's configuration tool
+
+| Directory                                                                                                 | Description                                                    |
+| --------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| [`/`](../../#scripts)                                                                                     | entry point                                                    |
+| [`configs/`](../../configs/#configs)                                                                      | configuration of operating systems                             |
+| [`deploy/`](../#deploy)                                                                                   | scripts and files to build firmware binaries                   |
+| [`deploy/coreboot-rom/`](../coreboot-rom/#deploy-coreboot-rom)                                            | (work in progress)                                             |
+| [`deploy/mixed-firmware/`](#deploy-mixed-firmware)                                                        | disk image solution                                            |
+| [`keys/`](../../keys/#keys)                                                                               | example certificates and signing keys                          |
+| [`operating-system/`](../../operating-system/#operating-system)                                           | folders including scripts ans files to build reprodu>          |
+| [`operating-system/debian/`](../../operating-system/debian/#operating-system-debian)                      | reproducible debian buster                                     |
+| [`operating-system/debian/docker/`](../../operating-system/debian/docker/#operating-system-debian-docker) | docker environment                                             |
+| [`stboot/`](../../stboot/#stboot)                                                                         | scripts and files to build stboot bootloader from source       |
+| [`stboot/include/`](../../stboot/include/#stboot-include)                                                 | fieles to be includes into the bootloader's initramfs          |
+| [`stboot/data/`](../../stboot/data/#stboot-data)                                                          | fieles to be placed on a data partition of the host            |
+| [`stconfig/`](../../stconfig/#stconfig)                                                                   | scripts and files to build the bootloader's configuration tool |
 
 ## Deploy Mixed-Firmware
-This deployment solution can be used if no direct control over the host default firmware is given. Since the *stboot* bootloader uses the *linuxboot* architecture it consists of a Linux kernel and an initfamfs, which can be treated as a usual operating system. The approach of this solution is to create an image including this kernel and initramfs. Additionally, the image contains an active boot partition with a separate bootloader written to it. *Syslinux* is used here.
 
-The image can then be written to the host's hard drive. During the boot process of the host's default firmware the *Syslinux* bootloader is called and hands over control to the *stboot bootloader finally.
+This deployment solution can be used if no direct control over the host default firmware is given. Since the _stboot_ bootloader uses the _linuxboot_ architecture it consists of a Linux kernel and an initfamfs, which can be treated as a usual operating system. The approach of this solution is to create an image including this kernel and initramfs. Additionally, the image contains an active boot partition with a separate bootloader written to it. _Syslinux_ is used here.
+
+The image can then be written to the host's hard drive. During the boot process of the host's default firmware the _Syslinux_ bootloader is called and hands over control to the \*stboot bootloader finally.
 
 ### Scripts
+
 #### `build_kernel.sh`
+
 This script is invoked by 'run.sh'. It downloads and veriifys sours code for Linux kernel version 4.19.6. The kernel is build according to 'x86_64_linuxboot_config' file. This kernel will be used as part of linuxboot. The script writes 'vmlinuz-linuxboot' in this directory.
 
 #### `create_image.sh`
-This script is invoked by 'run.sh'. Firstly it creates a raw image, secondly *sfdisk* is used to write the partitions table. Thirdly the script downloads *Syslinux* bootloader and installs it to the Master Boot Record and the Partition Boot Record respectively. Finally, the *linuxboot* kernel 'vmlinuz-linuxboot' is copied to the image. The output is 'MBR_Syslinux_Linuxboot.img'.
+
+This script is invoked by 'run.sh'. Firstly it creates a raw image, secondly _sfdisk_ is used to write the partitions table. Thirdly the script downloads _Syslinux_ bootloader and installs it to the Master Boot Record and the Partition Boot Record respectively. Finally, the _linuxboot_ kernel 'vmlinuz-linuxboot' is copied to the image. The output is 'MBR_Syslinux_Linuxboot.img'.
 
 Notice that the image is incomplete at this state. The appropriate initramfs need to be included.
 
 #### `mount_boot.sh`
+
 This script is for custom use. If you want to inspect or modify files of the boot partition (1st partition) of 'Syslinux_Linuxboot.img' use this script. It mounts the image via a loop device at a temporary directory. The path is printed to the console.
 
 #### `mount_data.sh`
+
 This script is for custom use. If you want to inspect or modify files of the data partition (2nd partition) of 'Syslinux_Linuxboot.img' use this script. It mounts the image via a loop device at a temporary directory. The path is printed to the console.
 
 #### `mv_hostvars_to_image.sh`
+
 Optional at the moment. This Script copies the 'hostvars.json' configuration file to the image.
 
 #### `mv_initrd_to_image.sh`
-this script is invoked by 'run.sh'. It copies the linuxboot initramfs including *stboot* to the image.
+
+this script is invoked by 'run.sh'. It copies the linuxboot initramfs including _stboot_ to the image.
 
 #### `umount_boot.sh`
+
 Counterpart of 'mount_boot.sh'.
 
 #### `umount_data.sh`
+
 Counterpart of 'mount_data.sh'.
 
 ### Configuration Files
+
 #### `mbr.table`
+
 This files describes the partition layout of the image
 
 #### `syslinux.cfg`
-This is the configuration file for *Syslinux*. The paths for kernel and initramfs are set here.
+
+This is the configuration file for _Syslinux_. The paths for kernel and initramfs are set here.
 
 #### `x86_64_linuxboot_config`
-This is the kernel config for the *linuxboot* kernel. In addition to x86_64 based *defconfig* the following is set:
+
+This is the kernel config for the _linuxboot_ kernel. In addition to x86_64 based _defconfig_ the following is set:
+
 ```
 Processor type and features  --->
     [*] Linux guest support --->
         [*] Enable Paravirtualization code
         [*] KVM Guest support (including kvmclock)
         [*] kexec file based system call
-        [*] kexec jump     
+        [*] kexec jump
 
 Device Drivers  --->
     Virtio drivers  --->
         <*> PCI driver for virtio devices
     [*] Block devices  --->
         <*> Virtio block driver
-        [*]     SCSI passthrough request for the Virtio block driver 
+        [*]     SCSI passthrough request for the Virtio block driver
     Character devices  --->
         <*> Hardware Random Number Generator Core support  --->
             <*>   VirtIO Random Number Generator support

--- a/keys/README.md
+++ b/keys/README.md
@@ -1,23 +1,27 @@
 ## Table of Content
-Directory | Description
------------- | -------------
-[`/`](../README.md#scripts) | entry point
-[`configs/`](../configs/README.md#configs) | configuration of operating systems
-[`deploy/`](../deploy/README.md#deploy) | scripts and files to build firmware binaries
-[`deploy/coreboot-rom/`](../deploy/coreboot-rom/README.md#deploy-coreboot-rom) | (work in progress)
-[`deploy/mixed-firmware/`](../deploy/mixed-firmware/README.md#deploy-mixed-firmware) | disk image solution
-[`keys/`](README.md#keys) | example certificates and signing keys
-[`operating-system/`](../operating-system/README.md#operating-system) | folders including scripts ans files to build reprodu>
-[`operating-system/debian/`](../operating-system/debian/README.md#operating-system-debian) | reproducible debian buster
-[`operating-system/debian/docker/`](../operating-system/debian/docker/README.md#operating-system-debian-docker) | docker environment
-[`stboot/`](../stboot/README.md#stboot) | scripts and files to build stboot bootloader from source
-[`stboot/include/`](../stboot/include/README.md#stboot-include) | fieles to be includes into the bootloader's initramfs
-[`stboot/data/`](../stboot/data/README.md#stboot-data) | fieles to be placed on a data partition of the host
-[`stconfig/`](../stconfig/README.md#stconfig) | scripts and files to build the bootloader's configuration tool
+
+| Directory                                                                                              | Description                                                    |
+| ------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------- |
+| [`/`](../#scripts)                                                                                     | entry point                                                    |
+| [`configs/`](../configs/#configs)                                                                      | configuration of operating systems                             |
+| [`deploy/`](../deploy/#deploy)                                                                         | scripts and files to build firmware binaries                   |
+| [`deploy/coreboot-rom/`](../deploy/coreboot-rom/#deploy-coreboot-rom)                                  | (work in progress)                                             |
+| [`deploy/mixed-firmware/`](../deploy/mixed-firmware/#deploy-mixed-firmware)                            | disk image solution                                            |
+| [`keys/`](#keys)                                                                                       | example certificates and signing keys                          |
+| [`operating-system/`](../operating-system/#operating-system)                                           | folders including scripts ans files to build reprodu>          |
+| [`operating-system/debian/`](../operating-system/debian/#operating-system-debian)                      | reproducible debian buster                                     |
+| [`operating-system/debian/docker/`](../operating-system/debian/docker/#operating-system-debian-docker) | docker environment                                             |
+| [`stboot/`](../stboot/#stboot)                                                                         | scripts and files to build stboot bootloader from source       |
+| [`stboot/include/`](../stboot/include/#stboot-include)                                                 | fieles to be includes into the bootloader's initramfs          |
+| [`stboot/data/`](../stboot/data/#stboot-data)                                                          | fieles to be placed on a data partition of the host            |
+| [`stconfig/`](../stconfig/#stconfig)                                                                   | scripts and files to build the bootloader's configuration tool |
 
 ## Keys
+
 This directory contains example data only.
 
 ### Scripts
+
 #### `generate_keys_and_certs.sh`
+
 This script is invoked by `run.sh`. It generates certificate authority (CA), a self signed root certificate and a set of 5 signing keys, certified by the CA.

--- a/operating-system/README.md
+++ b/operating-system/README.md
@@ -1,20 +1,20 @@
 ## Table of Content
 
-| Directory                                                                                   | Description                                                    |
-| ------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
-| [`/`](../README.md#scripts)                                                                 | entry point                                                    |
-| [`configs/`](../configs/README.md#configs)                                                  | configuration of operating systems                             |
-| [`deploy/`](../deploy/README.md#deploy)                                                     | scripts and files to build firmware binaries                   |
-| [`deploy/coreboot-rom/`](../deploy/coreboot-rom/README.md#deploy-coreboot-rom)              | (work in progress)                                             |
-| [`deploy/mixed-firmware/`](../deploy/mixed-firmware/README.md#deploy-mixed-firmware)        | disk image solution                                            |
-| [`keys/`](../keys/README.md#keys)                                                           | example certificates and signing keys                          |
-| [`operating-system/`](README.md#operating-system)                                           | folders including scripts ans files to build reprodu>          |
-| [`operating-system/debian/`](debian/README.md#operating-system-debian)                      | reproducible debian buster                                     |
-| [`operating-system/debian/docker/`](debian/docker/README.md#operating-system-debian-docker) | docker environment                                             |
-| [`stboot/`](../stboot/README.md#stboot)                                                     | scripts and files to build stboot bootloader from source       |
-| [`stboot/include/`](../stboot/include/README.md#stboot-include)                             | fieles to be includes into the bootloader's initramfs          |
-| [`stboot/data/`](../stboot/data/README.md#stboot-data)                                      | fieles to be placed on a data partition of the host            |
-| [`stconfig/`](../stconfig/README.md#stconfig)                                               | scripts and files to build the bootloader's configuration tool |
+| Directory                                                                          | Description                                                    |
+| ---------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| [`/`](../#scripts)                                                                 | entry point                                                    |
+| [`configs/`](../configs/#configs)                                                  | configuration of operating systems                             |
+| [`deploy/`](../deploy/#deploy)                                                     | scripts and files to build firmware binaries                   |
+| [`deploy/coreboot-rom/`](../deploy/coreboot-rom/#deploy-coreboot-rom)              | (work in progress)                                             |
+| [`deploy/mixed-firmware/`](../deploy/mixed-firmware/#deploy-mixed-firmware)        | disk image solution                                            |
+| [`keys/`](../keys/#keys)                                                           | example certificates and signing keys                          |
+| [`operating-system/`](#operating-system)                                           | folders including scripts ans files to build reprodu>          |
+| [`operating-system/debian/`](debian/#operating-system-debian)                      | reproducible debian buster                                     |
+| [`operating-system/debian/docker/`](debian/docker/#operating-system-debian-docker) | docker environment                                             |
+| [`stboot/`](../stboot/#stboot)                                                     | scripts and files to build stboot bootloader from source       |
+| [`stboot/include/`](../stboot/include/#stboot-include)                             | fieles to be includes into the bootloader's initramfs          |
+| [`stboot/data/`](../stboot/data/#stboot-data)                                      | fieles to be placed on a data partition of the host            |
+| [`stconfig/`](../stconfig/#stconfig)                                               | scripts and files to build the bootloader's configuration tool |
 
 ## Operating-System
 

--- a/operating-system/README.md
+++ b/operating-system/README.md
@@ -1,22 +1,23 @@
 ## Table of Content
-Directory | Description
------------- | -------------
-[`/`](../README.md#scripts) | entry point
-[`configs/`](../configs/README.md#configs) | configuration of operating systems
-[`deploy/`](../deploy/README.md#deploy) | scripts and files to build firmware binaries
-[`deploy/coreboot-rom/`](../deploy/coreboot-rom/README.md#deploy-coreboot-rom) | (work in progress)
-[`deploy/mixed-firmware/`](../deploy/mixed-firmware/README.md#deploy-mixed-firmware) | disk image solution
-[`keys/`](../keys/README.md#keys) | example certificates and signing keys
-[`operating-system/`](README.md#operating-system) | folders including scripts ans files to build reprodu>
-[`operating-system/debian/`](debian/README.md#operating-system-debian) | reproducible debian buster
-[`operating-system/debian/docker/`](debian/docker/README.md#operating-system-debian-docker) | docker environment
-[`stboot/`](../stboot/README.md#stboot) | scripts and files to build stboot bootloader from source
-[`stboot/include/`](../stboot/include/README.md#stboot-include) | fieles to be includes into the bootloader's initramfs
-[`stboot/data/`](../stboot/data/README.md#stboot-data) | fieles to be placed on a data partition of the host
-[`stconfig/`](../stconfig/README.md#stconfig) | scripts and files to build the bootloader's configuration tool
+
+| Directory                                                                                   | Description                                                    |
+| ------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| [`/`](../README.md#scripts)                                                                 | entry point                                                    |
+| [`configs/`](../configs/README.md#configs)                                                  | configuration of operating systems                             |
+| [`deploy/`](../deploy/README.md#deploy)                                                     | scripts and files to build firmware binaries                   |
+| [`deploy/coreboot-rom/`](../deploy/coreboot-rom/README.md#deploy-coreboot-rom)              | (work in progress)                                             |
+| [`deploy/mixed-firmware/`](../deploy/mixed-firmware/README.md#deploy-mixed-firmware)        | disk image solution                                            |
+| [`keys/`](../keys/README.md#keys)                                                           | example certificates and signing keys                          |
+| [`operating-system/`](README.md#operating-system)                                           | folders including scripts ans files to build reprodu>          |
+| [`operating-system/debian/`](debian/README.md#operating-system-debian)                      | reproducible debian buster                                     |
+| [`operating-system/debian/docker/`](debian/docker/README.md#operating-system-debian-docker) | docker environment                                             |
+| [`stboot/`](../stboot/README.md#stboot)                                                     | scripts and files to build stboot bootloader from source       |
+| [`stboot/include/`](../stboot/include/README.md#stboot-include)                             | fieles to be includes into the bootloader's initramfs          |
+| [`stboot/data/`](../stboot/data/README.md#stboot-data)                                      | fieles to be placed on a data partition of the host            |
+| [`stconfig/`](../stconfig/README.md#stconfig)                                               | scripts and files to build the bootloader's configuration tool |
 
 ## Operating-System
-The operating systems to be used with *System Transparency* need to be build reproducible. See http://docs.system-transparency.org for further information. 
 
-Currently, a reproducible *Debian* system is supported.
+The operating systems to be used with _System Transparency_ need to be build reproducible. See http://system-transparency.org for further information.
 
+Currently, a reproducible _Debian_ system is supported.

--- a/operating-system/debian/README.md
+++ b/operating-system/debian/README.md
@@ -1,20 +1,20 @@
 ## Table of Content
 
-| Directory                                                                               | Description                                                    |
-| --------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
-| [`/`](../../README.md#scripts)                                                          | entry point                                                    |
-| [`configs/`](../../configs/README.md#configs)                                           | configuration of operating systems                             |
-| [`deploy/`](../../deploy/README.md#deploy)                                              | scripts and files to build firmware binaries                   |
-| [`deploy/coreboot-rom/`](../../deploy/coreboot-rom/README.md#deploy-coreboot-rom)       | (work in progress)                                             |
-| [`deploy/mixed-firmware/`](../../deploy/mixed-firmware/README.md#deploy-mixed-firmware) | disk image solution                                            |
-| [`keys/`](../../keys/README.md#keys)                                                    | example certificates and signing keys                          |
-| [`operating-system/`](../README.md#operating-system)                                    | folders including scripts ans files to build reprodu>          |
-| [`operating-system/debian/`](README.md#operating-system-debian)                         | reproducible debian buster                                     |
-| [`operating-system/debian/docker/`](docker/README.md#operating-system-debian-docker)    | docker environment                                             |
-| [`stboot/`](../../stboot/README.md#stboot)                                              | scripts and files to build stboot bootloader from source       |
-| [`stboot/include/`](../../stboot/include/README.md#stboot-include)                      | fieles to be includes into the bootloader's initramfs          |
-| [`stboot/data/`](../../stboot/data/README.md#stboot-data)                               | fieles to be placed on a data partition of the host            |
-| [`stconfig/`](../../stconfig/README.md#stconfig)                                        | scripts and files to build the bootloader's configuration tool |
+| Directory                                                                      | Description                                                    |
+| ------------------------------------------------------------------------------ | -------------------------------------------------------------- |
+| [`/`](../../#scripts)                                                          | entry point                                                    |
+| [`configs/`](../../configs/#configs)                                           | configuration of operating systems                             |
+| [`deploy/`](../../deploy/#deploy)                                              | scripts and files to build firmware binaries                   |
+| [`deploy/coreboot-rom/`](../../deploy/coreboot-rom/#deploy-coreboot-rom)       | (work in progress)                                             |
+| [`deploy/mixed-firmware/`](../../deploy/mixed-firmware/#deploy-mixed-firmware) | disk image solution                                            |
+| [`keys/`](../../keys/#keys)                                                    | example certificates and signing keys                          |
+| [`operating-system/`](../#operating-system)                                    | folders including scripts ans files to build reprodu>          |
+| [`operating-system/debian/`](#operating-system-debian)                         | reproducible debian buster                                     |
+| [`operating-system/debian/docker/`](docker/#operating-system-debian-docker)    | docker environment                                             |
+| [`stboot/`](../../stboot/#stboot)                                              | scripts and files to build stboot bootloader from source       |
+| [`stboot/include/`](../../stboot/include/#stboot-include)                      | fieles to be includes into the bootloader's initramfs          |
+| [`stboot/data/`](../../stboot/data/#stboot-data)                               | fieles to be placed on a data partition of the host            |
+| [`stconfig/`](../../stconfig/#stconfig)                                        | scripts and files to build the bootloader's configuration tool |
 
 ## Operating-System Debian
 

--- a/operating-system/debian/README.md
+++ b/operating-system/debian/README.md
@@ -1,23 +1,27 @@
 ## Table of Content
-Directory | Description
------------- | -------------
-[`/`](../../README.md#scripts) | entry point
-[`configs/`](../../configs/README.md#configs) | configuration of operating systems
-[`deploy/`](../../deploy/README.md#deploy) | scripts and files to build firmware binaries
-[`deploy/coreboot-rom/`](../../deploy/coreboot-rom/README.md#deploy-coreboot-rom) | (work in progress)
-[`deploy/mixed-firmware/`](../../deploy/mixed-firmware/README.md#deploy-mixed-firmware) | disk image solution
-[`keys/`](../../keys/README.md#keys) | example certificates and signing keys
-[`operating-system/`](../README.md#operating-system) | folders including scripts ans files to build reprodu>
-[`operating-system/debian/`](README.md#operating-system-debian) | reproducible debian buster
-[`operating-system/debian/docker/`](docker/README.md#operating-system-debian-docker) | docker environment
-[`stboot/`](../../stboot/README.md#stboot) | scripts and files to build stboot bootloader from source
-[`stboot/include/`](../../stboot/include/README.md#stboot-include) | fieles to be includes into the bootloader's initramfs
-[`stboot/data/`](../../stboot/data/README.md#stboot-data) | fieles to be placed on a data partition of the host
-[`stconfig/`](../../stconfig/README.md#stconfig) | scripts and files to build the bootloader's configuration tool
+
+| Directory                                                                               | Description                                                    |
+| --------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| [`/`](../../README.md#scripts)                                                          | entry point                                                    |
+| [`configs/`](../../configs/README.md#configs)                                           | configuration of operating systems                             |
+| [`deploy/`](../../deploy/README.md#deploy)                                              | scripts and files to build firmware binaries                   |
+| [`deploy/coreboot-rom/`](../../deploy/coreboot-rom/README.md#deploy-coreboot-rom)       | (work in progress)                                             |
+| [`deploy/mixed-firmware/`](../../deploy/mixed-firmware/README.md#deploy-mixed-firmware) | disk image solution                                            |
+| [`keys/`](../../keys/README.md#keys)                                                    | example certificates and signing keys                          |
+| [`operating-system/`](../README.md#operating-system)                                    | folders including scripts ans files to build reprodu>          |
+| [`operating-system/debian/`](README.md#operating-system-debian)                         | reproducible debian buster                                     |
+| [`operating-system/debian/docker/`](docker/README.md#operating-system-debian-docker)    | docker environment                                             |
+| [`stboot/`](../../stboot/README.md#stboot)                                              | scripts and files to build stboot bootloader from source       |
+| [`stboot/include/`](../../stboot/include/README.md#stboot-include)                      | fieles to be includes into the bootloader's initramfs          |
+| [`stboot/data/`](../../stboot/data/README.md#stboot-data)                               | fieles to be placed on a data partition of the host            |
+| [`stconfig/`](../../stconfig/README.md#stconfig)                                        | scripts and files to build the bootloader's configuration tool |
 
 ## Operating-System Debian
-### Scripts
-#### `create_stconfig.sh`
-This script is invoked by `run.sh`. It creates a configuration directory for the *debian* system in `configs/` including a `stconfig.json` configuration file. This can also serve as template for custom configuration directories.
 
-See https://docs.system-transparency.org for further information about `stconfig.json`
+### Scripts
+
+#### `create_stconfig.sh`
+
+This script is invoked by `run.sh`. It creates a configuration directory for the _debian_ system in `configs/` including a `stconfig.json` configuration file. This can also serve as template for custom configuration directories.
+
+See https://system-transparency.org for further information about `stconfig.json`

--- a/operating-system/debian/docker/README.md
+++ b/operating-system/debian/docker/README.md
@@ -1,47 +1,59 @@
 ## Table of Content
-Directory | Description
------------- | -------------
-[`/`](../../../README.md#scripts) | entry point
-[`configs/`](../../../configs/README.md#configs) | configuration of operating systems
-[`deploy/`](../../../deploy/README.md#deploy) | scripts and files to build firmware binaries
-[`deploy/coreboot-rom/`](../../../deploy/coreboot-rom/README.md#deploy-coreboot-rom) | (work in progress)
-[`deploy/mixed-firmware/`](../../../deploy/mixed-firmware/README.md#deploy-mixed-firmware) | disk image solution
-[`keys/`](../../../keys/README.md#keys) | example certificates and signing keys
-[`operating-system/`](../../README.md#operating-system) | folders including scripts ans files to build reprodu>
-[`operating-system/debian/`](../README.md#operating-system-debian) | reproducible debian buster
-[`operating-system/debian/docker/`](README.md#operating-system-debian-docker) | docker environment
-[`stboot/`](../../../stboot/README.md#stboot) | scripts and files to build stboot bootloader from source
-[`stboot/include/`](../../../stboot/include/README.md#stboot-include) | fieles to be includes into the bootloader's initramfs
-[`stboot/data/`](../../../stboot/data/README.md#stboot-data) | fieles to be placed on a data partition of the host
-[`stconfig/`](../../../stconfig/README.md#stconfig) | scripts and files to build the bootloader's configuration tool
+
+| Directory                                                                         | Description                                                    |
+| --------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| [`/`](../../../#scripts)                                                          | entry point                                                    |
+| [`configs/`](../../../configs/#configs)                                           | configuration of operating systems                             |
+| [`deploy/`](../../../deploy/#deploy)                                              | scripts and files to build firmware binaries                   |
+| [`deploy/coreboot-rom/`](../../../deploy/coreboot-rom/#deploy-coreboot-rom)       | (work in progress)                                             |
+| [`deploy/mixed-firmware/`](../../../deploy/mixed-firmware/#deploy-mixed-firmware) | disk image solution                                            |
+| [`keys/`](../../../keys/#keys)                                                    | example certificates and signing keys                          |
+| [`operating-system/`](../../#operating-system)                                    | folders including scripts ans files to build reprodu>          |
+| [`operating-system/debian/`](../#operating-system-debian)                         | reproducible debian buster                                     |
+| [`operating-system/debian/docker/`](#operating-system-debian-docker)              | docker environment                                             |
+| [`stboot/`](../../../stboot/#stboot)                                              | scripts and files to build stboot bootloader from source       |
+| [`stboot/include/`](../../../stboot/include/#stboot-include)                      | fieles to be includes into the bootloader's initramfs          |
+| [`stboot/data/`](../../../stboot/data/#stboot-data)                               | fieles to be placed on a data partition of the host            |
+| [`stconfig/`](../../../stconfig/#stconfig)                                        | scripts and files to build the bootloader's configuration tool |
 
 ## Operating-System Debian Docker
+
 todo: intro
 
 ### Scripts
+
 #### `build_debian.sh`
+
 Invoked by `run.sh`. Todo...
 
 #### `pack-reproducible.sh`
-Part of *Debian* build process in *Docker*
+
+Part of _Debian_ build process in _Docker_
 
 #### `run-in-chroot.sh`
-Part of *Debian* build process in *Docker*
+
+Part of _Debian_ build process in _Docker_
 
 ### Configuration Files
+
 #### `debootstrap-buster.patch`
+
 todo ...
 
 #### `debos.yaml`
+
 todo ...
 
 #### `Dockerfile`
+
 todo ...
 
 ### Directories
+
 #### `out/`
+
 Built directory. The compiled kernel and initramfs are stored here.
 
 #### `overlays/`
-todo ...
 
+todo ...

--- a/stboot/README.md
+++ b/stboot/README.md
@@ -1,20 +1,20 @@
 ## Table of Content
 
-| Directory                                                                                                       | Description                                                    |
-| --------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
-| [`/`](../README.md#scripts)                                                                                     | entry point                                                    |
-| [`configs/`](../configs/README.md#configs)                                                                      | configuration of operating systems                             |
-| [`deploy/`](../deploy/README.md#deploy)                                                                         | scripts and files to build firmware binaries                   |
-| [`deploy/coreboot-rom/`](../deploy/coreboot-rom/README.md#deploy-coreboot-rom)                                  | (work in progress)                                             |
-| [`deploy/mixed-firmware/`](../deploy/mixed-firmware/README.md#deploy-mixed-firmware)                            | disk image solution                                            |
-| [`keys/`](../keys/README.md#keys)                                                                               | example certificates and signing keys                          |
-| [`operating-system/`](../operating-system/README.md#operating-system)                                           | folders including scripts ans files to build reprodu>          |
-| [`operating-system/debian/`](../operating-system/debian/README.md#operating-system-debian)                      | reproducible debian buster                                     |
-| [`operating-system/debian/docker/`](../operating-system/debian/docker/README.md#operating-system-debian-docker) | docker environment                                             |
-| [`stboot/`](README.md#stboot)                                                                                   | scripts and files to build stboot bootloader from source       |
-| [`stboot/include/`](include/README.md#stboot-include)                                                           | fieles to be includes into the bootloader's initramfs          |
-| [`stboot/data/`](data/README.md#stboot-data)                                                                    | fieles to be placed on a data partition of the host            |
-| [`stconfig/`](../stconfig/README.md#stconfig)                                                                   | scripts and files to build the bootloader's configuration tool |
+| Directory                                                                                              | Description                                                    |
+| ------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------- |
+| [`/`](../#scripts)                                                                                     | entry point                                                    |
+| [`configs/`](../configs/#configs)                                                                      | configuration of operating systems                             |
+| [`deploy/`](../deploy/#deploy)                                                                         | scripts and files to build firmware binaries                   |
+| [`deploy/coreboot-rom/`](../deploy/coreboot-rom/#deploy-coreboot-rom)                                  | (work in progress)                                             |
+| [`deploy/mixed-firmware/`](../deploy/mixed-firmware/#deploy-mixed-firmware)                            | disk image solution                                            |
+| [`keys/`](../keys/#keys)                                                                               | example certificates and signing keys                          |
+| [`operating-system/`](../operating-system/#operating-system)                                           | folders including scripts ans files to build reprodu>          |
+| [`operating-system/debian/`](../operating-system/debian/#operating-system-debian)                      | reproducible debian buster                                     |
+| [`operating-system/debian/docker/`](../operating-system/debian/docker/#operating-system-debian-docker) | docker environment                                             |
+| [`stboot/`](#stboot)                                                                                   | scripts and files to build stboot bootloader from source       |
+| [`stboot/include/`](include/#stboot-include)                                                           | fieles to be includes into the bootloader's initramfs          |
+| [`stboot/data/`](data/#stboot-data)                                                                    | fieles to be placed on a data partition of the host            |
+| [`stconfig/`](../stconfig/#stconfig)                                                                   | scripts and files to build the bootloader's configuration tool |
 
 ## Stboot
 

--- a/stboot/README.md
+++ b/stboot/README.md
@@ -1,37 +1,44 @@
 ## Table of Content
-Directory | Description
------------- | -------------
-[`/`](../README.md#scripts) | entry point
-[`configs/`](../configs/README.md#configs) | configuration of operating systems
-[`deploy/`](../deploy/README.md#deploy) | scripts and files to build firmware binaries
-[`deploy/coreboot-rom/`](../deploy/coreboot-rom/README.md#deploy-coreboot-rom) | (work in progress)
-[`deploy/mixed-firmware/`](../deploy/mixed-firmware/README.md#deploy-mixed-firmware) | disk image solution
-[`keys/`](../keys/README.md#keys) | example certificates and signing keys
-[`operating-system/`](../operating-system/README.md#operating-system) | folders including scripts ans files to build reprodu>
-[`operating-system/debian/`](../operating-system/debian/README.md#operating-system-debian) | reproducible debian buster
-[`operating-system/debian/docker/`](../operating-system/debian/docker/README.md#operating-system-debian-docker) | docker environment
-[`stboot/`](README.md#stboot) | scripts and files to build stboot bootloader from source
-[`stboot/include/`](include/README.md#stboot-include) | fieles to be includes into the bootloader's initramfs
-[`stboot/data/`](data/README.md#stboot-data) | fieles to be placed on a data partition of the host
-[`stconfig/`](../stconfig/README.md#stconfig) | scripts and files to build the bootloader's configuration tool
+
+| Directory                                                                                                       | Description                                                    |
+| --------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| [`/`](../README.md#scripts)                                                                                     | entry point                                                    |
+| [`configs/`](../configs/README.md#configs)                                                                      | configuration of operating systems                             |
+| [`deploy/`](../deploy/README.md#deploy)                                                                         | scripts and files to build firmware binaries                   |
+| [`deploy/coreboot-rom/`](../deploy/coreboot-rom/README.md#deploy-coreboot-rom)                                  | (work in progress)                                             |
+| [`deploy/mixed-firmware/`](../deploy/mixed-firmware/README.md#deploy-mixed-firmware)                            | disk image solution                                            |
+| [`keys/`](../keys/README.md#keys)                                                                               | example certificates and signing keys                          |
+| [`operating-system/`](../operating-system/README.md#operating-system)                                           | folders including scripts ans files to build reprodu>          |
+| [`operating-system/debian/`](../operating-system/debian/README.md#operating-system-debian)                      | reproducible debian buster                                     |
+| [`operating-system/debian/docker/`](../operating-system/debian/docker/README.md#operating-system-debian-docker) | docker environment                                             |
+| [`stboot/`](README.md#stboot)                                                                                   | scripts and files to build stboot bootloader from source       |
+| [`stboot/include/`](include/README.md#stboot-include)                                                           | fieles to be includes into the bootloader's initramfs          |
+| [`stboot/data/`](data/README.md#stboot-data)                                                                    | fieles to be placed on a data partition of the host            |
+| [`stconfig/`](../stconfig/README.md#stconfig)                                                                   | scripts and files to build the bootloader's configuration tool |
 
 ## Stboot
-*Stboot* itself is part of the *u-root* project (https://github.com/u-root/u-root) and is written in Go. Since *Stboot* is still in a beta phase at the moment, the code resides at https://github.com/u-root/u-root/tree/stboot branch. This directory mainly provides utilities for the ongoing development.
 
-One part of the *u-root* project is the 'u-root' command to create an initramfs (an archive of files) to use with Linux kernels. Another part is a collection of bootloaders implemented in Go. *Stboot* is one of these bootloaders.
+_Stboot_ itself is part of the _u-root_ project (https://github.com/u-root/u-root) and is written in Go. Since _Stboot_ is still in a beta phase at the moment, the code resides at https://github.com/u-root/u-root/tree/stboot branch. This directory mainly provides utilities for the ongoing development.
+
+One part of the _u-root_ project is the 'u-root' command to create an initramfs (an archive of files) to use with Linux kernels. Another part is a collection of bootloaders implemented in Go. _Stboot_ is one of these bootloaders.
 
 ### Scripts
+
 #### `create_hostvars.sh`
-This script is invoked by 'run.sh'. It creates an example 'hostvars.json' file. This can be used as a template for a custom 'hostvars.json'. See https://docs.system-transparency.org for further information about this configuration file.
+
+This script is invoked by 'run.sh'. It creates an example 'hostvars.json' file. This can be used as a template for a custom 'hostvars.json'. See https://system-transparency.org for further information about this configuration file.
 Choose one of the following flags when calling:
-* `d` : empty IP. This will trigger DHCP
-* `q` : IP configuration suitable for *QEMU*
+
+- `d` : empty IP. This will trigger DHCP
+- `q` : IP configuration suitable for _QEMU_
 
 #### `install_u-root.sh`
-This script is invoked by 'run.sh'. It downloads the source code for the 'u-root' command and the *Stboot* bootloader and compiles them. Further it installs a special *uinit* binary from https://github.com/system-transparency/uinit needed to call the bootloader from the initramfs' init-script.
+
+This script is invoked by 'run.sh'. It downloads the source code for the 'u-root' command and the _Stboot_ bootloader and compiles them. Further it installs a special _uinit_ binary from https://github.com/system-transparency/uinit needed to call the bootloader from the initramfs' init-script.
 
 #### `make_initrmafs.sh`
-This script is invoked by 'run.sh'. It uses the 'u-root' command to build 'initramfs-linuxboot.cpio' including the *uinit* binary, the *Stboot* bootloader and further files from the 'include/' directory.
-This 'initramfs-linuxboot.cpio' is the core component of each deployment solution of *System Transparency's* firmware part.
 
-This script accepts a '-d' flag. It then includes the full set of available *Go* commands into the initfamfs to enable debugging — e.g before *uinit* hands over control to the *Stboot* bootloader or in case of a bootloader panic.
+This script is invoked by 'run.sh'. It uses the 'u-root' command to build 'initramfs-linuxboot.cpio' including the _uinit_ binary, the _Stboot_ bootloader and further files from the 'include/' directory.
+This 'initramfs-linuxboot.cpio' is the core component of each deployment solution of _System Transparency's_ firmware part.
+
+This script accepts a '-d' flag. It then includes the full set of available _Go_ commands into the initfamfs to enable debugging — e.g before _uinit_ hands over control to the _Stboot_ bootloader or in case of a bootloader panic.

--- a/stboot/data/README.md
+++ b/stboot/data/README.md
@@ -1,36 +1,45 @@
 ## Table of Content
-Directory | Description
------------- | -------------
-[`/`](../../README.md#scripts) | entry point
-[`configs/`](../../configs/README.md#configs) | configuration of operating systems
-[`deploy/`](../../deploy/README.md#deploy) | scripts and files to build firmware binaries
-[`deploy/coreboot-rom/`](../../deploy/coreboot-rom/README.md#deploy-coreboot-rom) | (work in progress)
-[`deploy/mixed-firmware/`](../../deploy/mixed-firmware/README.md#deploy-mixed-firmware) | disk image solution
-[`keys/`](../../keys/README.md#keys) | example certificates and signing keys
-[`operating-system/`](../../operating-system/README.md#operating-system) | folders including scripts ans files to build reprodu>
-[`operating-system/debian/`](../../operating-system/debian/README.md#operating-system-debian) | reproducible debian buster
-[`operating-system/debian/docker/`](../../operating-system/debian/docker/README.md#operating-system-debian-docker) | docker environment
-[`stboot/`](../README.md#stboot) | scripts and files to build stboot bootloader from source
-[`stboot/include/`](../include/README.md#stboot-include) | fieles to be includes into the bootloader's initramfs
-[`stboot/data/`](README.md#stboot-data) | fieles to be placed on a data partition of the host
-[`stconfig/`](../../stconfig/README.md#stconfig) | scripts and files to build the bootloader's configuration tool
+
+| Directory                                                                                                 | Description                                                    |
+| --------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| [`/`](../../#scripts)                                                                                     | entry point                                                    |
+| [`configs/`](../../configs/#configs)                                                                      | configuration of operating systems                             |
+| [`deploy/`](../../deploy/#deploy)                                                                         | scripts and files to build firmware binaries                   |
+| [`deploy/coreboot-rom/`](../../deploy/coreboot-rom/#deploy-coreboot-rom)                                  | (work in progress)                                             |
+| [`deploy/mixed-firmware/`](../../deploy/mixed-firmware/#deploy-mixed-firmware)                            | disk image solution                                            |
+| [`keys/`](../../keys/#keys)                                                                               | example certificates and signing keys                          |
+| [`operating-system/`](../../operating-system/#operating-system)                                           | folders including scripts ans files to build reprodu>          |
+| [`operating-system/debian/`](../../operating-system/debian/#operating-system-debian)                      | reproducible debian buster                                     |
+| [`operating-system/debian/docker/`](../../operating-system/debian/docker/#operating-system-debian-docker) | docker environment                                             |
+| [`stboot/`](../#stboot)                                                                                   | scripts and files to build stboot bootloader from source       |
+| [`stboot/include/`](../include/#stboot-include)                                                           | fieles to be includes into the bootloader's initramfs          |
+| [`stboot/data/`](#stboot-data)                                                                            | fieles to be placed on a data partition of the host            |
+| [`stconfig/`](../../stconfig/#stconfig)                                                                   | scripts and files to build the bootloader's configuration tool |
 
 ## Stboot Data
+
 Files in this foder are ment to be places at a data partition at the host machine. This partition will be mounted by the bootloader.
 
 ### Scripts
+
 #### `create_example_data.sh`
+
 This script is invoked by 'run.sh'. It creates the files listed below with example data.
 
 ### Configuration Files
+
 #### `network.json` (will be generated)
+
 See https://www.system-transparency.org/usage/network.json
 
 #### `provisioning-servers.json` (will be generated)
+
 See https://www.system-transparency.org/usage/provisioning-servers.json
 
 #### `https-root-certificates.pem` (will be generated)
+
 See https://www.system-transparency.org/usage/https-root-certificates.pem
 
 #### `ntp-servers.json` (will be generated)
+
 See https://www.system-transparency.org/usage/ntp-servers.json

--- a/stboot/include/README.md
+++ b/stboot/include/README.md
@@ -1,26 +1,31 @@
 ## Table of Content
-Directory | Description
------------- | -------------
-[`/`](../../README.md#scripts) | entry point
-[`configs/`](../../configs/README.md#configs) | configuration of operating systems
-[`deploy/`](../../deploy/README.md#deploy) | scripts and files to build firmware binaries
-[`deploy/coreboot-rom/`](../../deploy/coreboot-rom/README.md#deploy-coreboot-rom) | (work in progress)
-[`deploy/mixed-firmware/`](../../deploy/mixed-firmware/README.md#deploy-mixed-firmware) | disk image solution
-[`keys/`](../../keys/README.md#keys) | example certificates and signing keys
-[`operating-system/`](../../operating-system/README.md#operating-system) | folders including scripts ans files to build reprodu>
-[`operating-system/debian/`](../../operating-system/debian/README.md#operating-system-debian) | reproducible debian buster
-[`operating-system/debian/docker/`](../../operating-system/debian/docker/README.md#operating-system-debian-docker) | docker environment
-[`stboot/`](../README.md#stboot) | scripts and files to build stboot bootloader from source
-[`stboot/include/`](README.md#stboot-include) | fieles to be includes into the bootloader's initramfs
-[`stboot/data/`](../data/README.md#stboot-data) | fieles to be placed on a data partition of the host
-[`stconfig/`](../../stconfig/README.md#stconfig) | scripts and files to build the bootloader's configuration tool
+
+| Directory                                                                                                 | Description                                                    |
+| --------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| [`/`](../../#scripts)                                                                                     | entry point                                                    |
+| [`configs/`](../../configs/#configs)                                                                      | configuration of operating systems                             |
+| [`deploy/`](../../deploy/#deploy)                                                                         | scripts and files to build firmware binaries                   |
+| [`deploy/coreboot-rom/`](../../deploy/coreboot-rom/#deploy-coreboot-rom)                                  | (work in progress)                                             |
+| [`deploy/mixed-firmware/`](../../deploy/mixed-firmware/#deploy-mixed-firmware)                            | disk image solution                                            |
+| [`keys/`](../../keys/#keys)                                                                               | example certificates and signing keys                          |
+| [`operating-system/`](../../operating-system/#operating-system)                                           | folders including scripts ans files to build reprodu>          |
+| [`operating-system/debian/`](../../operating-system/debian/#operating-system-debian)                      | reproducible debian buster                                     |
+| [`operating-system/debian/docker/`](../../operating-system/debian/docker/#operating-system-debian-docker) | docker environment                                             |
+| [`stboot/`](../#stboot)                                                                                   | scripts and files to build stboot bootloader from source       |
+| [`stboot/include/`](#stboot-include)                                                                      | fieles to be includes into the bootloader's initramfs          |
+| [`stboot/data/`](../data/#stboot-data)                                                                    | fieles to be placed on a data partition of the host            |
+| [`stconfig/`](../../stconfig/#stconfig)                                                                   | scripts and files to build the bootloader's configuration tool |
 
 ## Stboot Include
+
 Files in this folder will be included into the stboot bootloader directly.
 
 ### Files
+
 #### `hostvars.json` (will be generated)
+
 Bootloader configuration data. See https://www.system-transparency.org/usage/hostvars.json
 
 #### `netsetup.elv`
+
 Elvish shell script to be used for debugging purposes.

--- a/stconfig/README.md
+++ b/stconfig/README.md
@@ -1,20 +1,20 @@
 ## Table of Content
 
-| Directory                                                                                                       | Description                                                    |
-| --------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
-| [`/`](../README.md#scripts)                                                                                     | entry point                                                    |
-| [`configs/`](../configs/README.md#configs)                                                                      | configuration of operating systems                             |
-| [`deploy/`](../deploy/README.md#deploy)                                                                         | scripts and files to build firmware binaries                   |
-| [`deploy/coreboot-rom/`](../deploy/coreboot-rom/README.md#deploy-coreboot-rom)                                  | (work in progress)                                             |
-| [`deploy/mixed-firmware/`](../deploy/mixed-firmware/README.md#deploy-mixed-firmware)                            | disk image solution                                            |
-| [`keys/`](../keys/README.md#keys)                                                                               | example certificates and signing keys                          |
-| [`operating-system/`](../operating-system/README.md#operating-system)                                           | folders including scripts ans files to build reprodu>          |
-| [`operating-system/debian/`](../operating-system/debian/README.md#operating-system-debian)                      | reproducible debian buster                                     |
-| [`operating-system/debian/docker/`](../operating-system/debian/docker/README.md#operating-system-debian-docker) | docker environment                                             |
-| [`stboot/`](../stboot/README.md#stboot)                                                                         | scripts and files to build stboot bootloader from source       |
-| [`stboot/include/`](../stboot/include/README.md#stboot-include)                                                 | fieles to be includes into the bootloader's initramfs          |
-| [`stboot/data/`](../stboot/data/README.md#stboot-data)                                                          | fieles to be placed on a data partition of the host            |
-| [`stconfig/`](README.md#stconfig)                                                                               | scripts and files to build the bootloader's configuration tool |
+| Directory                                                                                              | Description                                                    |
+| ------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------- |
+| [`/`](../#scripts)                                                                                     | entry point                                                    |
+| [`configs/`](../configs/#configs)                                                                      | configuration of operating systems                             |
+| [`deploy/`](../deploy/#deploy)                                                                         | scripts and files to build firmware binaries                   |
+| [`deploy/coreboot-rom/`](../deploy/coreboot-rom/#deploy-coreboot-rom)                                  | (work in progress)                                             |
+| [`deploy/mixed-firmware/`](../deploy/mixed-firmware/#deploy-mixed-firmware)                            | disk image solution                                            |
+| [`keys/`](../keys/#keys)                                                                               | example certificates and signing keys                          |
+| [`operating-system/`](../operating-system/#operating-system)                                           | folders including scripts ans files to build reprodu>          |
+| [`operating-system/debian/`](../operating-system/debian/#operating-system-debian)                      | reproducible debian buster                                     |
+| [`operating-system/debian/docker/`](../operating-system/debian/docker/#operating-system-debian-docker) | docker environment                                             |
+| [`stboot/`](../stboot/#stboot)                                                                         | scripts and files to build stboot bootloader from source       |
+| [`stboot/include/`](../stboot/include/#stboot-include)                                                 | fieles to be includes into the bootloader's initramfs          |
+| [`stboot/data/`](../stboot/data/#stboot-data)                                                          | fieles to be placed on a data partition of the host            |
+| [`stconfig/`](#stconfig)                                                                               | scripts and files to build the bootloader's configuration tool |
 
 ## Stconfig
 

--- a/stconfig/README.md
+++ b/stconfig/README.md
@@ -1,33 +1,39 @@
 ## Table of Content
-Directory | Description
------------- | -------------
-[`/`](../README.md#scripts) | entry point
-[`configs/`](../configs/README.md#configs) | configuration of operating systems
-[`deploy/`](../deploy/README.md#deploy) | scripts and files to build firmware binaries
-[`deploy/coreboot-rom/`](../deploy/coreboot-rom/README.md#deploy-coreboot-rom) | (work in progress)
-[`deploy/mixed-firmware/`](../deploy/mixed-firmware/README.md#deploy-mixed-firmware) | disk image solution
-[`keys/`](../keys/README.md#keys) | example certificates and signing keys
-[`operating-system/`](../operating-system/README.md#operating-system) | folders including scripts ans files to build reprodu>
-[`operating-system/debian/`](../operating-system/debian/README.md#operating-system-debian) | reproducible debian buster
-[`operating-system/debian/docker/`](../operating-system/debian/docker/README.md#operating-system-debian-docker) | docker environment
-[`stboot/`](../stboot/README.md#stboot) | scripts and files to build stboot bootloader from source
-[`stboot/include/`](../stboot/include/README.md#stboot-include) | fieles to be includes into the bootloader's initramfs
-[`stboot/data/`](../stboot/data/README.md#stboot-data) | fieles to be placed on a data partition of the host
-[`stconfig/`](README.md#stconfig) | scripts and files to build the bootloader's configuration tool
+
+| Directory                                                                                                       | Description                                                    |
+| --------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| [`/`](../README.md#scripts)                                                                                     | entry point                                                    |
+| [`configs/`](../configs/README.md#configs)                                                                      | configuration of operating systems                             |
+| [`deploy/`](../deploy/README.md#deploy)                                                                         | scripts and files to build firmware binaries                   |
+| [`deploy/coreboot-rom/`](../deploy/coreboot-rom/README.md#deploy-coreboot-rom)                                  | (work in progress)                                             |
+| [`deploy/mixed-firmware/`](../deploy/mixed-firmware/README.md#deploy-mixed-firmware)                            | disk image solution                                            |
+| [`keys/`](../keys/README.md#keys)                                                                               | example certificates and signing keys                          |
+| [`operating-system/`](../operating-system/README.md#operating-system)                                           | folders including scripts ans files to build reprodu>          |
+| [`operating-system/debian/`](../operating-system/debian/README.md#operating-system-debian)                      | reproducible debian buster                                     |
+| [`operating-system/debian/docker/`](../operating-system/debian/docker/README.md#operating-system-debian-docker) | docker environment                                             |
+| [`stboot/`](../stboot/README.md#stboot)                                                                         | scripts and files to build stboot bootloader from source       |
+| [`stboot/include/`](../stboot/include/README.md#stboot-include)                                                 | fieles to be includes into the bootloader's initramfs          |
+| [`stboot/data/`](../stboot/data/README.md#stboot-data)                                                          | fieles to be placed on a data partition of the host            |
+| [`stconfig/`](README.md#stconfig)                                                                               | scripts and files to build the bootloader's configuration tool |
 
 ## Stconfig
-*Stboot* itself is part of the *u-root* project (https://github.com/u-root/u-root) and is written in Go. Since *Stboot* is still in a beta phase at the moment, the code resides at https://github.com/u-root/u-root/tree/stboot branch. This directory mainly provides utilities for the ongoing development.
 
-The *u-root* project also includes some tools related to its various commands. *Stconfig* is a tool for the host's operator to prepare a 'stboot.ball' file for the provisioning server. This file is downloaded to the host during the *Stboot's* bootprocess. *Stboot* is heavily dependent on that 'stboot.ball' being prepared by this tool.
+_Stboot_ itself is part of the _u-root_ project (https://github.com/u-root/u-root) and is written in Go. Since _Stboot_ is still in a beta phase at the moment, the code resides at https://github.com/u-root/u-root/tree/stboot branch. This directory mainly provides utilities for the ongoing development.
 
-See https://docs.system-transparency.org for further information about 'stconfig.json' and 'stboot.ball'.
+The _u-root_ project also includes some tools related to its various commands. _Stconfig_ is a tool for the host's operator to prepare a 'stboot.ball' file for the provisioning server. This file is downloaded to the host during the _Stboot's_ bootprocess. _Stboot_ is heavily dependent on that 'stboot.ball' being prepared by this tool.
+
+See https://system-transparency.org for further information about 'stconfig.json' and 'stboot.ball'.
 
 ### Scripts
+
 #### `install_stconfig.sh`
+
 This script is invoked by 'run.sh'. It downloads and installs the 'stconfig' tool.
 
 #### `create_and_sign_bootball.sh`
+
 This script is invoked by 'run.sh'. It uses 'stconfig' to create a 'stboot.ball' from the 'stconfig.json' in the 'configs/' directory. The path to a dedicated configuration directory is passed to the script. Further it uses 'stconfig' to sign the generated 'stboot.ball' with the example keys from 'keys/'.
 
 #### `upload_bootball.sh`
-This script is invoked by 'run.sh'. It uploads the 'stboot.ball' file to the provisioning server. SSH access to the server is needed. See https://docs.system-transparency.org for further information about the provisioning server.
+
+This script is invoked by 'run.sh'. It uploads the 'stboot.ball' file to the provisioning server. SSH access to the server is needed. See https://system-transparency.org for further information about the provisioning server.


### PR DESCRIPTION
## What this does:
- [x] Remove all references to `docs.system-transparency.org` as they lead nowhere
- [x] Made code easier to navigate on GitHub by removing references to README files which are rendered anyway
- [x] Ran standard markdown formatter on all README files