### PR TITLE
give qemu 2G RAM

### DIFF
--- a/run.config
+++ b/run.config
@@ -23,4 +23,4 @@ ST_PROVISIONING_SERVER_URL=
 
 # ST_QEMU_MEM is the amount of RAM for qemu guests, in megabytes.
 #ST_QEMU_MEM=8192
-ST_QEMU_MEM=1024
+ST_QEMU_MEM=2048


### PR DESCRIPTION
1G is not enough to fit the rootfs of a default Debian, as it's being
built by us. 2G leaves 371M free space to play with.