### PR TITLE
scripts: Make swtpm mandatory

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -24,6 +24,8 @@ checkMISC
 echo ""
 echo "Checking environment ..."
 checkDebootstrap
+checkSwtpmSetup
+checkSwtpm
 
 # Global build configuration
 global_config=${root}/run.config

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -99,3 +99,31 @@ function checkDebootstrap {
     echo "Filesystem for debootstrap OK"
 }
 
+function checkSwtpmSetup {
+   command -v swtpm_setup.sh >/dev/null 2>&1 || {
+      echo >&2 "swtpm_setup.sh required";
+      exit 1;
+   }
+
+   echo "swtpm_setup.sh supported"
+}
+
+function checkSwtpm {
+   minver=("0" "2")
+
+   command -v swtpm >/dev/null 2>&1 || {
+      echo >&2 "swtpm required";
+      exit 1;
+   }
+
+   ver=$(swtpm --version | cut -d ' ' -f 4 | sed 's/,//')
+   majorver="$(echo $ver | cut -d . -f 1)"
+   minorver="$(echo $ver | cut -d . -f 2)"
+
+   if [ "$majorver" -le "${minver[0]}" ] && [ "$minorver" -lt "${minver[1]}" ]; then
+         echo "swtpm version ${majorver}.${minorver} is not supported. Needs version ${minver[0]}.${minver[1]} or later."
+         exit 1
+   else
+       echo "swtpm 0.2.0 supported"
+   fi
+}

--- a/scripts/start_qemu_mixed-firmware.sh
+++ b/scripts/start_qemu_mixed-firmware.sh
@@ -73,3 +73,5 @@ qemu-system-x86_64 \
   -chardev socket,id=chrtpm,path=/$tpm/swtpm-sock \
   -tpmdev emulator,id=tpm0,chardev=chrtpm \
   -device tpm-tis,tpmdev=tpm0
+
+rm -r $tpm/*

--- a/scripts/start_qemu_mixed-firmware.sh
+++ b/scripts/start_qemu_mixed-firmware.sh
@@ -15,6 +15,52 @@ source ${root}/run.config
 mem=${ST_QEMU_MEM}
 image="${root}/stboot/mixed-firmware/STBoot_mixed_firmware.img"
 
+i=0
+while [ -d /tmp/mytpm$i ]; do
+  let i=i+1
+done
+tpm=/tmp/mytpm$i
+
+mkdir $tpm
+
+if [ -z "${XDG_CONFIG_HOME:-}" ]; then
+  export XDG_CONFIG_HOME=~/.config
+fi
+
+if [ ! -f "${XDG_CONFIG_HOME}/swtpm-localca.conf" ]; then
+  cat <<EOF > "${XDG_CONFIG_HOME}/swtpm-localca.conf"
+statedir = ${XDG_CONFIG_HOME}/var/lib/swtpm-localca
+signingkey = ${XDG_CONFIG_HOME}/var/lib/swtpm-localca/signkey.pem
+issuercert = ${XDG_CONFIG_HOME}/var/lib/swtpm-localca/issuercert.pem
+certserial = ${XDG_CONFIG_HOME}/var/lib/swtpm-localca/certserial
+EOF
+fi
+
+if [ ! -f "${XDG_CONFIG_HOME}/swtpm-localca.options" ]; then
+  cat <<EOF > "${XDG_CONFIG_HOME}/swtpm-localca.options"
+--platform-manufacturer SystemTransparency
+--platform-version 2.12
+--platform-model QEMU
+EOF
+fi
+
+if [ ! -f "${XDG_CONFIG_HOME}/swtpm_setup.conf" ]; then
+   cat <<EOF > "${XDG_CONFIG_HOME}/swtpm_setup.conf"
+# Program invoked for creating certificates
+create_certs_tool= /usr/share/swtpm/swtpm-localca
+create_certs_tool_config = ${XDG_CONFIG_HOME}/swtpm-localca.conf
+create_certs_tool_options = ${XDG_CONFIG_HOME}/swtpm-localca.options
+EOF
+fi
+
+# Note: TPM1 needs to access tcsd as root..
+swtpm_setup.sh --tpmstate $tpm --tpm2 \
+  --create-ek-cert --create-platform-cert --lock-nvram
+
+echo "Starting $tpm"
+swtpm socket --tpmstate dir=$tpm --tpm2 --ctrl type=unixio,path=/$tpm/swtpm-sock &
+
+
 qemu-system-x86_64 \
   -drive if=virtio,file="${image}",format=raw \
   -nographic \
@@ -23,4 +69,7 @@ qemu-system-x86_64 \
   -object rng-random,filename=/dev/urandom,id=rng0 \
   -device virtio-rng-pci,rng=rng0 \
   -rtc base=localtime \
-  -m "${mem}"
+  -m "${mem}" \
+  -chardev socket,id=chrtpm,path=/$tpm/swtpm-sock \
+  -tpmdev emulator,id=tpm0,chardev=chrtpm \
+  -device tpm-tis,tpmdev=tpm0


### PR DESCRIPTION
Check for swtpm 0.2.0 and make it mandatory.
Use it to start the mixed firmware qemu bundle.

Signed-off-by: Patrick Rudolph <patrick.rudolph@9elements.com>