### PR TITLE
make_kernel: Fix dependency tracking

### DIFF
--- a/stboot/make_kernel.sh
+++ b/stboot/make_kernel.sh
@@ -40,12 +40,18 @@ keyring=${src_cache}/gnupg/keyring.gpg
 # ---
 
 # Copy initramfs to build directory
-
 cp "${dir}/initramfs-linuxboot.cpio.gz" "${build_src}/initramfs-linuxboot.cpio.gz"
-
 # ---
 
 # Kernel build setup
+if [ -f "${kernel_output_file_name}" ]; then
+  if [ -z ${kernel_output_file_name##*.efi} ]; then
+    if [[ "${dir}/initramfs-linuxboot.cpio.gz" -nt "${kernel_output_file_name}" ]]; then
+      # Force rebuild as initrd changed. FIXME: Use makefile
+      rm "${kernel_output_file_name}"
+    fi
+  fi
+fi
 
 if [ -f "${kernel_output_file_name}" ]; then
     while true; do


### PR DESCRIPTION
Rebuild kernel if EFI stub is to be build and initramfs is newer than
the kernel.

Signed-off-by: Patrick Rudolph <patrick.rudolph@9elements.com>