### PR TITLE
bugfix wrong defconfig

### DIFF
--- a/stboot-installation/mbr-bootloader/make_mbr_bootloader.sh
+++ b/stboot-installation/mbr-bootloader/make_mbr_bootloader.sh
@@ -29,7 +29,7 @@ echo "cmdline: ${cmdline}"
 cp "${kernel_config}" "${kernel_config}.patch"
 sed -i "s/CONFIG_CMDLINE=.*/CONFIG_CMDLINE=\"${cmdline}\"/" "${kernel_config}.patch"
 
-bash "${common}/build_kernel.sh" "${root}/${kernel_config}" "${kernel_out}" "${kernel_version}"
+bash "${common}/build_kernel.sh" "${root}/${kernel_config}.patch" "${kernel_out}" "${kernel_version}"
 
 bash "${dir}/build_syslinux_config.sh"
 


### PR DESCRIPTION
line 29 creates copy of the defconfig for the kernel with $NAME.patch
line 30 replaces kernelcommandline to the value of run.config in this $NAME.patch
line 32 builds the kernel with original, unpatched defconfig