### PR TITLE
Support newer GCC versions

### DIFF
--- a/operating-system/common/build_tboot.sh
+++ b/operating-system/common/build_tboot.sh
@@ -41,6 +41,11 @@ echo ""
 echo "[INFO]: Building tboot"
 echo ""
 cd "${cache}/code"
+currentver="$(gcc -dumpversion | cut -d . -f 1)"
+if [ "$currentver" -ge "9" ]; then
+    export CFLAGS="-Wno-error=address-of-packed-member"
+    export TBOOT_CFLAGS="$CFLAGS"
+fi
 make dist --no-print-directory
 cd "${dir}"
 cp "${cache}/code/dist/boot/tboot.gz" "${tboot}"

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -50,23 +50,23 @@ function checkMISC {
 }
 
 function checkGCC {
-   maxver="9"
+   #maxver="9"
 
    command -v gcc >/dev/null 2>&1 || {
       echo >&2 "GCC required";
       exit 1;
    }
 
-   currentver="$(gcc -dumpversion | cut -d . -f 1)"
+   #currentver="$(gcc -dumpversion | cut -d . -f 1)"
 
-   if [ "$currentver" -gt "$maxver" ]; then
-         echo "GCC version ${currentver} is not supported. Needs version ${maxver} or earlier."
-	 echo "Hint: If you've got multiple versions of GCC installed, update-alternatives(1) might "
-	 echo "help with configuring which one should be invoked when issuing the gcc command."
-         exit 1
-   else
-       echo "GCC supported"
-   fi
+   #if [ "$currentver" -gt "$maxver" ]; then
+   #      echo "GCC version ${currentver} is not supported. Needs version ${maxver} or earlier."
+   #      echo "Hint: If you've got multiple versions of GCC installed, update-alternatives(1) might "
+   #      echo "help with configuring which one should be invoked when issuing the gcc command."
+   #      exit 1
+   #else
+   #    echo "GCC supported"
+   #fi
 }
 
 function checkGO {


### PR DESCRIPTION
gcc9 introduces a new flag "address-of-packed-member", which causes an error
during the build of tboot. To support newer gcc the flag
"-Wno-error=address-of-packed-member"  is included on all concerned gcc
versions.

Tested on:

- gcc (Ubuntu 8.4.0-4ubuntu1) 8.4.0
- gcc (Ubuntu 9.3.0-18ubuntu1) 9.3.0
- gcc (GCC) 10.2.1 20201125 (Red Hat 10.2.1-9)