### PR TITLE
stboot-installation/mbr-bootloader: Add fetch_syslinux.sh

### DIFF
--- a/stboot-installation/mbr-bootloader/build_image.sh
+++ b/stboot-installation/mbr-bootloader/build_image.sh
@@ -28,16 +28,6 @@ fi
 
 if [ ! -d "${out}" ]; then mkdir -p "${out}"; fi
 
-if [ -d "${syslinux_cache}" ]; then
-    echo "[INFO]: Using cached Syslinux in $(realpath --relative-to="${root}" "${syslinux_cache}")"
-else
-    mkdir -p "${syslinux_cache}"
-    echo
-    echo "[INFO]: Downloading Syslinux Bootloader"
-    wget "${syslinux_src}/${syslinux_tar}" -P "${syslinux_cache}"
-    tar -xf "${syslinux_cache}/${syslinux_tar}" -C "${syslinux_cache}"
-fi
-
 echo
 echo "[INFO]: Constructing disk image from filesystems:"
 echo "[INFO]: Using : $(realpath --relative-to="${root}" "${boot_filesystem}")"

--- a/stboot-installation/mbr-bootloader/fetch_syslinux.sh
+++ b/stboot-installation/mbr-bootloader/fetch_syslinux.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+# set -o xtrace
+
+# Set magic variables for current file & dir
+dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root="$(cd "${dir}/../../" && pwd)"
+
+syslinux_src="https://mirrors.edge.kernel.org/pub/linux/utils/boot/syslinux/"
+syslinux_tar="syslinux-6.03.tar.xz"
+syslinux_cache="${root}/cache/syslinux/"
+
+
+if [ -d "${syslinux_cache}" ]; then
+    echo "[INFO]: Using cached Syslinux in $(realpath --relative-to="${root}" "${syslinux_cache}")"
+else
+    mkdir -p "${syslinux_cache}"
+    echo
+    echo "[INFO]: Downloading Syslinux Bootloader"
+    wget "${syslinux_src}/${syslinux_tar}" -P "${syslinux_cache}"
+    tar -xf "${syslinux_cache}/${syslinux_tar}" -C "${syslinux_cache}"
+fi
+
+trap - EXIT

--- a/stboot-installation/mbr-bootloader/make_mbr_bootloader.sh
+++ b/stboot-installation/mbr-bootloader/make_mbr_bootloader.sh
@@ -35,6 +35,8 @@ bash "${dir}/build_syslinux_config.sh"
 
 bash "${common}/build_host_config.sh"
 
+bash "${dir}/fetch_syslinux.sh"
+
 bash "${dir}/build_boot_filesystem.sh"
 
 bash "${common}/build_data_filesystem.sh"


### PR DESCRIPTION
This commit fixes the MBR bootloader build.

build_boot_filesystem.sh needs the syslinux fetch, which is is done
in build_image.sh. Therefor make_mbr_bootloader does not work on a
clean repository. This commit creates a separate script for fetching
syslinux and is called in make_mbr_bootloade.sh to call it before
bould_boot_filesystem.sh.

Signed-off-by: Marcello Sylvester Bauer <sylv@sylv.io>