### PR TITLE
Use isolated gopath in cache/go

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,19 +10,6 @@ Detailed information about the project itself can be found at https://system-tra
 * The operator machine should run a Linux system (tested with Ubuntu 18.04.2 LTS (Bionic Beaver) / Kernel 4.15.0-47-generic
 * Further software prerequisites will be checked during setup. For details take a look at `./scripts/checks.sh`. 
 
-Regarding Golang:
-* make sure to also create a workspace at `$HOME/go` (see [test Go](https://golang.org/doc/install#testing))
-* make sure `$HOME/go/bin` and `/usr/local/go/bin` or '/usr/bin/go are added to `PATH` environment variable
-  * you may have to disable `GO111MODULE` via `go env -w GO111MODULE=off`
-
-If the dependency checks complains about your GCC, You need to make GCC 8 the default:
-
-```bash
-sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 100 --slave /usr/bin/g++ g++ /usr/bin/g++-8
-sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 100 --slave /usr/bin/g++ g++ /usr/bin/g++-9
-sudo update-alternatives --config gcc
-```
-
 ## Quick Start
 
 ```bash

--- a/operating-system/common/get_acms.sh
+++ b/operating-system/common/get_acms.sh
@@ -9,6 +9,7 @@ set -o nounset
 dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 root="$(cd "${dir}/../../" && pwd)"
 
+gopath="${root}/cache/go"
 cache="${root}/cache/ACMs"
 
 if [ -d "${cache}" ]; then
@@ -19,7 +20,7 @@ else
     echo ""
     echo "[INFO]: Grebbing all available ACMs from Intel"
     echo ""
-    sinit-acm-grebber -of "${cache}"
+    ${gopath}/bin/sinit-acm-grebber -of "${cache}"
 
     echo "ACMs saved at: $(realpath --relative-to="${root}" "${cache}")"
 fi

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -87,8 +87,6 @@ function checkGO {
    else
        echo "GO supported"
    fi
-
-   echo "$PATH"|grep -q "$(go env GOPATH)/bin" || { echo "$(go env GOPATH)/bin must be added to PATH"; exit 1; }
 }
 
 function checkDebootstrap {

--- a/scripts/create_and_sign_os_package.sh
+++ b/scripts/create_and_sign_os_package.sh
@@ -9,6 +9,8 @@ set -o nounset
 dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 root="$(cd "${dir}/../" && pwd)"
 
+gopath="${root}/cache/go"
+
 # import global configuration
 source "${root}/run.config"
 
@@ -32,14 +34,14 @@ output_path="${out}/${os_pkg_name}"
 
 if [ ! -d "${out}" ]; then mkdir -p "${out}"; fi
 
-echo "[INFO]: call 'stmanager create' to pack boot files into an OS package."
+echo "[INFO]: call '${gopath}/bin/stmanager create' to pack boot files into an OS package."
 
 stmanager_create_args=( "--out=${output_path}" "--label=${os_pkg_label}" "--kernel=${os_pkg_kernel}" "--cmd=${os_pkg_cmdline}" "--tcmd=${os_pkg_tboot_args}" "--cert=${os_pkg_signing_root}")
 [ -z "${os_pkg_initramfs}" ] || stmanager_create_args+=( "--initramfs=${os_pkg_initramfs}" )
 [ -z "${os_pkg_tboot}" ] || stmanager_create_args+=( "--tboot=${os_pkg_tboot}" )
 [ -z "${os_pkg_acm}" ] || stmanager_create_args+=( "--acm=${os_pkg_acm}" )
 
-os_pkg_name=$(stmanager create "${stmanager_create_args[@]}")
+os_pkg_name=$(${gopath}/bin/stmanager create "${stmanager_create_args[@]}")
 os_pkg="${out}/${os_pkg_name}"
 
 echo "[INFO]: created OS package ${os_pkg_name}"
@@ -50,7 +52,7 @@ signing_key_dir="${root}/out/keys/signing_keys"
 echo "[INFO]: call 'stmanager sign' to sign $os_pkg with example keys"
 for I in 1 2 3 4 5
 do
-    stmanager sign --key="${signing_key_dir}/signing-key-${I}.key" --cert="${signing_key_dir}/signing-key-${I}.cert" "$os_pkg"
+    ${gopath}/bin/stmanager sign --key="${signing_key_dir}/signing-key-${I}.key" --cert="${signing_key_dir}/signing-key-${I}.cert" "$os_pkg"
 done
 
 # local boot order configuration
@@ -78,5 +80,5 @@ cp "${os_pkg}" "${root}/.newest-ospkg.zip"
 
 echo ""
 echo "[INFO]: $(realpath --relative-to="${root}" "$os_pkg") created and signed with example keys."
-echo "[INFO]: You can use stmanager manually, too. Try 'stmanager --help'"
+echo "[INFO]: You can use stmanager manually, too. Try '${gopath}/bin/stmanager --help'"
 echo "[INFO]: Edit ${local_boot_order_file} to change boot order for local boot method"

--- a/scripts/make_toolchain.sh
+++ b/scripts/make_toolchain.sh
@@ -12,14 +12,7 @@ root="$(cd "${dir}/../" && pwd)"
 # import global configuration
 source ${root}/run.config
 
-gopath="$(go env GOPATH)"
-if [ -z "${gopath}" ]; then
-    echo "GOPATH is not set!"
-    echo "Please refer to https://golang.org/cmd/go/#hdr-GOPATH_environment_variable1"
-    exit 1
-fi
-
-#TODO: check if GOPATH/bin is in PATH
+gopath="${root}/cache/go"
 
 uroot_repo="github.com/u-root/u-root"
 uroot_src="${gopath}/src/${uroot_repo}"

--- a/stboot-installation/common/build_initramfs.sh
+++ b/stboot-installation/common/build_initramfs.sh
@@ -26,12 +26,7 @@ cpu_keys="${root}/out/keys/cpu_keys"
 
 variant=${ST_LINUXBOOT_VARIANT}
 
-gopath=$(go env GOPATH)
-if [ -z "${gopath}" ]; then
-    echo "GOPATH is not set!"
-    echo "Please refer to https://golang.org/cmd/go/#hdr-GOPATH_environment_variable1"
-    echo -e "creating initramfs $failed"; exit 1;
-fi
+gopath="${root}/cache/go"
 
 if [ -f "${initramfs_compressed}" ]; then
     echo
@@ -45,7 +40,7 @@ case $variant in
 "minimal" )
     echo
     echo "[INFO]: creating minimal initramfs including stboot only"
-    GOPATH="${gopath}" u-root -build=bb -uinitcmd=stboot -defaultsh="" -o "${initramfs}" \
+    GOPATH="${gopath}" ${gopath}/bin/u-root -build=bb -uinitcmd=stboot -defaultsh="" -o "${initramfs}" \
     -files "${security_config}:etc/$(basename "${security_config}")" \
     -files "${https_roots}:etc/$(basename "${https_roots}")" \
     github.com/u-root/u-root/cmds/core/init \


### PR DESCRIPTION
Instead of using global GOPATH, create an own gopath in cache/go.
In addition use the git commit to fetch u-root and checkout the remote branch to avoid errors when the local branch diverges, due to a remote rebase.