### PR TITLE
build: Re-add GO111MODULE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ endif
 ifeq ($(GOPATH),)
 GOPATH := $(CURDIR)/cache/go
 endif
+GO111MODULE := off
 
 ## logging color
 ifneq ($(TERM),)

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,10 @@ MAKEPID:= $(shell echo $$PPID)
 
 # setup development environment if ST_DEVELOP=1
 ifeq ($(patsubst "%",%,$(ST_DEVELOP)),1)
-	# use local GOPATH
+# use local GOPATH
+ifeq ($(ST_GOPATH),)
 	GOPATH := $(shell source <(go env) && echo $$GOPATH)
+endif
 endif
 
 # use custom GOPATH
@@ -35,12 +37,10 @@ GOPATH := $(ST_GOPATH)
 else
 $(error ST_GOPATH have to be an absolute path!)
 endif
-endif
-
-# default GOPATH
-ifeq ($(GOPATH),)
+else
 GOPATH := $(CURDIR)/cache/go
 endif
+# disable go modules
 GO111MODULE := off
 
 ## logging color


### PR DESCRIPTION
The GO111MODULE environment variable was removed, which broke the
build. Let us re-add it.

Fixes: 88149e54498b ("Makefile: export all variable")
Signed-off-by: Björn Töpel <bjorn@mullvad.net>