### PR TITLE
fix gcc11 (Fedora 34)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,19 +79,20 @@ OUTREDIRECT :=  > /dev/null
 endif
 endif
 
+## commented out: Emulate grouped target on all make versions
+#
 # make "grouped targets" are only supported since version 4.3
-MAKE_VER_MAYOR := $(word 1,$(subst ., ,$(MAKE_VERSION)))
-MAKE_VER_MINOR := $(word 2,$(subst ., ,$(MAKE_VERSION)))
-ifeq ($(shell [ $(MAKE_VER_MAYOR) -ge "4" ] && echo y),y)
-ifeq ($(shell [ $(MAKE_VER_MINOR) -ge "3" ] && echo y),y)
-GROUP_TARGET := &
-endif
-endif
+#MAKE_VER_MAYOR := $(word 1,$(subst ., ,$(MAKE_VERSION)))
+#MAKE_VER_MINOR := $(word 2,$(subst ., ,$(MAKE_VERSION)))
+#ifeq ($(shell [ $(MAKE_VER_MAYOR) -ge "4" ] && echo y),y)
+#ifeq ($(shell [ $(MAKE_VER_MINOR) -ge "3" ] && echo y),y)
+#GROUP_TARGET := &
+#endif
+#endif
 
-# HACK: If "grouped targets" are not supported, emulate the same behavior by removing
-#       grouped targets from target dependecies.
+# HACK: Emulate grouped target, to support make version <4.3
 define GROUP
-$(if $(GROUP_TARGET),$(1),$(word 1,$(1)))
+$(word 1,$(1))
 endef
 
 # Make uses maximal available job threads by default
@@ -262,7 +263,7 @@ toolchain: go-tools
 
 keygen: keygen-sign keygen-cpu
 
-keygen-sign $(EXAMPLE_ROOT_CERT) $(EXAMPLE_KEYS_CERTS)$(GROUG_TARGET): $(stmanager_bin)
+keygen-sign $(EXAMPLE_ROOT_CERT) $(EXAMPLE_KEYS_CERTS) &: $(stmanager_bin)
 	# WARN if example keys are used to build installation
 	if [ "$@" != keygen-sign ]; then \
 	  $(call LOG,WARN,Using example signing certs and keys for installation); \
@@ -271,9 +272,7 @@ keygen-sign $(EXAMPLE_ROOT_CERT) $(EXAMPLE_KEYS_CERTS)$(GROUG_TARGET): $(stmanag
 	$(scripts)/make_signing_keys.sh $(OUTREDIRECT)
 	@$(call LOG,DONE,Example signing keys in:,$(dir $(ROOT_CERT)))
 
-keygen-cpu: $(call GROUP,$(CPU_SSH_KEYS))
-
-$(call GROUP,$(CPU_SSH_KEYS))$(GROUP_TARGET):
+keygen-cpu $(CPU_SSH_KEYS):
 	@$(call LOG,INFO,Generate example cpu ssh keys)
 	$(scripts)/make_cpu_keys.sh $(OUTREDIRECT)
 	@$(call LOG,DONE,Example cpu ssh keys in:,$(CPU_KEY_DIR))

--- a/modules/go.mk
+++ b/modules/go.mk
@@ -82,7 +82,7 @@ else
 	git -C $(debos_src) checkout --quiet $(debos_branch)
 endif
 	touch $@
-$(debos_bin): $(debos_checkout)
+debos $(debos_bin): $(debos_checkout)
 	$(call go_update,debos,$(debos_bin),$(debos_package)/cmd/debos)
 
 ### u-root/stmanager
@@ -106,22 +106,21 @@ else
 	git -C $(u-root_src) checkout --quiet $(u-root_branch)
 endif
 	touch $@
-u-root $(u-root_bin)$(GROUP_TARGET): $(u-root_checkout)
+u-root $(u-root_bin): $(u-root_checkout)
 	$(call go_update,u-root,$(u-root_bin),$(u-root_package))
-stmanager $(stmanager_bin)$(GROUP_TARGET): $(u-root_checkout)
+stmanager $(stmanager_bin): $(u-root_checkout)
 	$(call go_update,stmanager,$(stmanager_bin),$(u-root_package)/tools/stmanager)
 
 ### cpu command
 
-cpu $(cpu_bin) $(cpud_bin)$(GROUP_TARGET):
+cpu $(cpu_bin) $(cpud_bin):
 	@$(call LOG,INFO,Go: Get,$(cpu_package))
 	go get -d -u $(cpu_package)
 	$(call go_update,cpu,$(cpu_bin),$(cpu_package))
 	$(call go_update,cpud,$(cpud_bin),$(cpud_package))
 
 ### ACM grebber
-
-sinit-acm-grebber $(sinit-acm-grebber_bin)$(GROUP_TARGET):
+sinit-acm-grebber $(sinit-acm-grebber_bin):
 	@$(call LOG,INFO,Go: Get,$(sinit-acm-grebber_package))
 	go get -d -u $(sinit-acm-grebber_package)
 	$(call go_update,sinit-acm-grebber,$(sinit-acm-grebber_bin),$(sinit-acm-grebber_package))

--- a/operating-system/Makefile.inc
+++ b/operating-system/Makefile.inc
@@ -11,12 +11,18 @@ include $(op)/debos/Makefile.inc
 
 tboot_code := $(tboot-cache)/code/.unpack
 
-_TBOOT_CFLAGS="-Wno-error=address-of-packed-member"
 gcc_version := $(shell gcc -dumpversion | cut -d . -f 1)
 
 ifeq ($(shell [[ "$(gcc_version)" -ge "9" ]] && echo $$?),0)
-tboot_env := CFLAGS=$(_TBOOT_CFLAGS) TBOOT_CFLAGS=$(_TBOOT_CFLAGS)
+_TBOOT_CFLAGS += -Wno-error=address-of-packed-member
 endif
+ifeq ($(shell [[ "$(gcc_version)" -ge "11" ]] && echo $$?),0)
+_TBOOT_CFLAGS += -Wno-error=stringop-overflow
+_TBOOT_CFLAGS += -Wno-error=maybe-uninitialized
+_TBOOT_CFLAGS += -Wno-error=array-parameter
+endif
+
+tboot_env := CFLAGS="$(_TBOOT_CFLAGS)" TBOOT_CFLAGS="$(_TBOOT_CFLAGS)"
 
 $(tboot_code):
 	rm -rf $(tboot-cache)

--- a/operating-system/debos/Makefile.inc
+++ b/operating-system/debos/Makefile.inc
@@ -223,7 +223,7 @@ define SETUP_DEBOS_CONTAINER
 	$1 build --build-arg="BASE_IMAGE=$(debos-base-image)" --build-arg="BASE_TAG=$(debos-base-tag)" \
 		--build-arg="DEBOS_REPO=$(debos_repo)" --build-arg="DEBOS_BRANCH=$(debos_branch)" \
 		-q -t $(debos-image) $(op)/debos;
-	@$(call LOG,DONE,$* debos image $(debos-image))
+	@$(call LOG,DONE,debos $1 image $(debos-image))
 endef
 
 SOURCE_DATE_EPOCH := $(shell git log -1 --format=format:%ct)
@@ -249,7 +249,7 @@ endif
 ifneq ($5,)
 $1-debos-suite-arg := --template-var=suite:$5
 endif
-$(op-out)/$3 $(op-out)/$4$(GROUP_TARGET): $2 $(debos-dep)
+$(op-out)/$3 $(op-out)/$4: $2 $(debos-dep)
 	mkdir -p $$(dir $$@)
 	$(debos-check)
 	$(debos-setup)

--- a/stboot-installation/common/build_initramfs.sh
+++ b/stboot-installation/common/build_initramfs.sh
@@ -40,7 +40,7 @@ if [ ! -d "${out}" ]; then mkdir -p "${out}"; fi
 
 # cache stderr in a file to run silently on success
 rc=0
-stderr_log=$(tempfile)
+stderr_log=$(mktemp)
 trap "rm ${stderr_log}" EXIT
 
 case $variant in


### PR DESCRIPTION
Ignore more compile flags on gcc11 for compiling tboot.

Signed-off-by: Marcello Sylvester Bauer <sylv@sylv.io>