### PR TITLE
Feature/stdata extra space

### DIFF
--- a/contrib/default.config
+++ b/contrib/default.config
@@ -86,10 +86,12 @@ ST_USE_PKG_CACHE=false
 #
 ST_KERNEL_VERSION=5.10.21
 
-# Size of the data partition in bytes. If empty, the size is set to match the
-# size of all nessesary files copied to the partition plus 100MB.
-ST_DATA_PARTITION_SZIZE=""
+# ST_DATA_PARTITION_EXTRA_SPACE defines additional storage space of the data
+# partition in bytes.
+# Suffixes like 'K', 'M', 'G', 'T' are supported. (case insensitive)
+# A minimum of 100M is recommended. (corresponds to 100 MiB)
 
+ST_DATA_PARTITION_EXTRA_SPACE="100M"
 
 ##############################################################################
 # STBoot Bootloader - MBR bootloader installation

--- a/stboot-installation/common/Makefile.inc
+++ b/stboot-installation/common/Makefile.inc
@@ -11,7 +11,7 @@ security_config := $(st-out)/security_configuration.json
 os-out_dirs = $(shell find $(os-out) -type d 2>/dev/null)
 os-out_files = $(shell find $(os-out) -type f -name '*' 2>/dev/null)
 
-$(eval $(call CONFIG_DEP,$(data_partition),ST_DATA_PARTITION_SZIZE))
+$(eval $(call CONFIG_DEP,$(data_partition),ST_DATA_PARTITION_EXTRA_SPACE))
 # build and sign example os-package, if directy is empty
 ifeq ($(os-out_files),)
 $(data_partition): % : %.config example-os-package

--- a/stboot-installation/common/build_data_filesystem.sh
+++ b/stboot-installation/common/build_data_filesystem.sh
@@ -12,24 +12,33 @@ root="$(cd "${dir}/../../" && pwd)"
 # import global configuration
 source "${DOTCONFIG:-.config}"
 
+toBytes() {
+ echo $1 | echo $((`sed 's/.*/\L\0/;s/t/Xg/;s/g/Xm/;s/m/Xk/;s/k/X/;s/b//;s/X/ *1024/g'`))
+}
+
 out="${root}/out/stboot-installation"
 name="data_partition.ext4"
 fs="${out}/${name}"
 local_boot_order_file_name="boot_order"
 local_boot_order_file="${root}/out/os-packages/${local_boot_order_file_name}"
 os_pkg_dir="${root}/out/os-packages"
-size_ext4="${ST_DATA_PARTITION_SZIZE}"
 
 if [ ! -d "${os_pkg_dir}" ]; then mkdir -p "${os_pkg_dir}"; fi
 
-# if empty set to size of os_pkg_dir + 100MB
-if [ -z "${size_ext4}" ]; then size_ext4=$(( $(du -b "${os_pkg_dir}" | cut -f1) +(100*(1<<20)) )); fi
+size_data_used=$(( $(du -b "${os_pkg_dir}" | cut -f1) ))
+size_data_extra=$(toBytes "${ST_DATA_PARTITION_EXTRA_SPACE:-0}")
+
+#size_data=$(( 20000000 + ${size_data_used} + ${size_data_extra} ))
+size_data=$(( ${size_data_used} + ${size_data_extra} ))
+inode_size=256
+inode_ratio=16384
+size_ext4=$(echo "scale=6;(${size_data}*(1.10+(${inode_size}/${inode_ratio})))+1" | bc -l | xargs printf "%0.f")
 
 echo
 echo "[INFO]: Creating EXT4 filesystems for STDATA partition:"
 
 if [ -f "${fs}.tmp" ]; then rm "${fs}.tmp"; fi
-mkfs.ext4 -L "STDATA" "${fs}.tmp" $((size_ext4 >> 10))
+mkfs.ext4 -I "${inode_size}" -i "${inode_ratio}" -L "STDATA" "${fs}.tmp" $((${size_ext4} >> 10))
 
 e2mkdir "${fs}.tmp":/stboot
 e2mkdir "${fs}.tmp":/stboot/etc

--- a/stboot-installation/common/build_data_filesystem.sh
+++ b/stboot-installation/common/build_data_filesystem.sh
@@ -28,30 +28,32 @@ if [ -z "${size_ext4}" ]; then size_ext4=$(( $(du -b "${os_pkg_dir}" | cut -f1) 
 echo
 echo "[INFO]: Creating EXT4 filesystems for STDATA partition:"
 
-if [ -f "${fs}" ]; then rm "${fs}"; fi
-mkfs.ext4 -L "STDATA" "${fs}" $((size_ext4 >> 10))
+if [ -f "${fs}.tmp" ]; then rm "${fs}.tmp"; fi
+mkfs.ext4 -L "STDATA" "${fs}.tmp" $((size_ext4 >> 10))
 
-e2mkdir "${fs}":/stboot
-e2mkdir "${fs}":/stboot/etc
-e2mkdir "${fs}":/stboot/os_pkgs
-e2mkdir "${fs}":/stboot/os_pkgs/local
-e2mkdir "${fs}":/stboot/os_pkgs/cache
+e2mkdir "${fs}.tmp":/stboot
+e2mkdir "${fs}.tmp":/stboot/etc
+e2mkdir "${fs}.tmp":/stboot/os_pkgs
+e2mkdir "${fs}.tmp":/stboot/os_pkgs/local
+e2mkdir "${fs}.tmp":/stboot/os_pkgs/cache
 
 echo
 echo "[INFO]: Writing UNIX timestamp"
 timestamp_file="${out}/system_time_fix"
 date +%s > "${timestamp_file}"
 cat "${timestamp_file}"
-e2cp "${timestamp_file}" "${fs}":/stboot/etc
+e2cp "${timestamp_file}" "${fs}.tmp":/stboot/etc
 rm "${timestamp_file}"
 
 echo
 echo "[INFO]: Copying OS packages to image (for local boot method)"
 ls -l "${root}/out/os-packages/."
-e2cp "${local_boot_order_file}" "${fs}":/stboot/os_pkgs/local
+e2cp "${local_boot_order_file}" "${fs}.tmp":/stboot/os_pkgs/local
 for i in "${os_pkg_dir}"/*; do
   [ -e "$i" ] || continue
-  e2cp "$i" "${fs}":/stboot/os_pkgs/local
+  e2cp "$i" "${fs}.tmp":/stboot/os_pkgs/local
 done
+
+mv ${fs}{.tmp,}
 
 trap - EXIT

--- a/stboot-installation/common/build_initramfs.sh
+++ b/stboot-installation/common/build_initramfs.sh
@@ -65,7 +65,7 @@ case $variant in
 "full" )
     echo
     echo "[INFO]: creating initramfs including all u-root core tools"
-    GOPATH="${gopath}" u-root -build=bb -uinitcmd=stboot -o "${initramfs}.tmp" \
+    GOPATH="${gopath}" ${gopath}/bin/u-root -build=bb -uinitcmd=stboot -o "${initramfs}.tmp" \
     -files "${security_config}:etc/$(basename "${security_config}")" \
     -files "${signing_root}:etc/${signing_root_name}" \
     -files "${https_roots}:etc/$(basename "${https_roots}")" \

--- a/stboot-installation/efi-application/build_boot_filesystem.sh
+++ b/stboot-installation/efi-application/build_boot_filesystem.sh
@@ -22,16 +22,18 @@ size_vfat=$((12*(1<<20)))
 echo "[INFO]: Using kernel (efi stub): $(realpath --relative-to="${root}" "${linuxboot_kernel}")"
 
 # mkfs.vfat requires size as an (undefined) block-count; seem to be units of 1k
-if [ -f "${fs}" ]; then rm "${fs}"; fi
-mkfs.vfat -C -n "STBOOT" "${fs}" $((size_vfat >> 10))
+if [ -f "${fs}.tmp" ]; then rm "${fs}.tmp"; fi
+mkfs.vfat -C -n "STBOOT" "${fs}.tmp" $((size_vfat >> 10))
 
 echo "[INFO]: Installing STBOOT.EFI"
-mmd -i "${fs}" ::EFI
-mmd -i "${fs}" ::EFI/BOOT
+mmd -i "${fs}.tmp" ::EFI
+mmd -i "${fs}.tmp" ::EFI/BOOT
 
-mcopy -i "${fs}" "${linuxboot_kernel}" ::/EFI/BOOT/BOOTX64.EFI
+mcopy -i "${fs}.tmp" "${linuxboot_kernel}" ::/EFI/BOOT/BOOTX64.EFI
 
 echo "[INFO]: Writing host cofiguration"
-mcopy -i "${fs}" "${host_config}" ::
+mcopy -i "${fs}.tmp" "${host_config}" ::
+
+mv ${fs}{.tmp,}
 
 trap - EXIT

--- a/stboot-installation/mbr-bootloader/build_boot_filesystem.sh
+++ b/stboot-installation/mbr-bootloader/build_boot_filesystem.sh
@@ -26,21 +26,24 @@ echo "[INFO]: Using kernel: $(realpath --relative-to="${root}" "${linuxboot_kern
 
 echo
 # mkfs.vfat requires size as an (undefined) block-count; seem to be units of 1k
-if [ -f "${fs}" ]; then rm "${fs}"; fi
-mkfs.vfat -C -n "STBOOT" "${fs}" $((size_vfat >> 10))
+if [ -f "${fs}.tmp" ]; then rm "${fs}.tmp"; fi
+mkfs.vfat -C -n "STBOOT" "${fs}.tmp" $((size_vfat >> 10))
 
 echo "[INFO]: Installing Syslinux"
-mmd -i "${fs}" ::syslinux
+mmd -i "${fs}.tmp" ::syslinux
 
-"${syslinux_cache}/${syslinux_dir}/bios/mtools/syslinux" --directory /syslinux/ --install "${fs}"
+"${syslinux_cache}/${syslinux_dir}/bios/mtools/syslinux" --directory /syslinux/ --install "${fs}.tmp"
 
 echo "[INFO]: Installing linuxboot kernel"
-mcopy -i "${fs}" "${linuxboot_kernel}" ::
+mcopy -i "${fs}.tmp" "${linuxboot_kernel}" ::
 
 echo "[INFO]: Writing syslinux config"
-mcopy -i "${fs}" "${syslinux_config}" ::syslinux/
+mcopy -i "${fs}.tmp" "${syslinux_config}" ::syslinux/
 
 echo "[INFO]: Writing host cofiguration"
-mcopy -i "${fs}" "${host_config}" ::
+mcopy -i "${fs}.tmp" "${host_config}" ::
+
+echo "[INFO]: Done VFAT filesystems for STBOOT partition"
+mv ${fs}{.tmp,}
 
 trap - EXIT

--- a/stboot-installation/mbr-bootloader/build_image.sh
+++ b/stboot-installation/mbr-bootloader/build_image.sh
@@ -12,19 +12,12 @@ root="$(cd "${dir}/../../" && pwd)"
 out="${root}/out/stboot-installation/mbr-bootloader"
 name="stboot_mbr_installation.img"
 img="${out}/${name}"
-img_backup="${img}.backup"
 syslinux_src="https://mirrors.edge.kernel.org/pub/linux/utils/boot/syslinux/"
 syslinux_tar="syslinux-6.03.tar.xz"
 syslinux_dir="syslinux-6.03"
 syslinux_cache="${root}/cache/syslinux/"
 boot_filesystem="${out}/boot_partition.vfat"
 data_filesystem="${out}/../data_partition.ext4"
-
-if [ -f "${img}" ]; then
-    echo
-    echo "[INFO]: backup existing image to $(realpath --relative-to="${root}" "${img_backup}")"
-    mv "${img}" "${img_backup}"
-fi
 
 if [ ! -d "${out}" ]; then mkdir -p "${out}"; fi
 
@@ -42,20 +35,22 @@ offset_vfat=$(( alignment/512 ))
 offset_ext4=$(( (alignment + size_vfat + alignment)/512 ))
 
 # insert the filesystem to a new file at offset 1MB
-dd if="${boot_filesystem}" of="${img}" conv=notrunc obs=512 status=none seek=${offset_vfat}
-dd if="${data_filesystem}" of="${img}" conv=notrunc obs=512 status=none seek=${offset_ext4}
+dd if="${boot_filesystem}" of="${img}.tmp" conv=notrunc obs=512 status=none seek=${offset_vfat}
+dd if="${data_filesystem}" of="${img}.tmp" conv=notrunc obs=512 status=none seek=${offset_ext4}
 
 # extend the file by 1MB
-truncate -s "+${alignment}" "${img}"
+truncate -s "+${alignment}" "${img}.tmp"
 
 echo "[INFO]: Adding partitions to disk image:"
 
 # apply partitioning
-parted -s --align optimal "${img}" mklabel gpt mkpart "STBOOT" fat32 "$((offset_vfat * 512))B" "$((offset_vfat * 512 + size_vfat))B" mkpart "STDATA" ext4 "$((offset_ext4 * 512))B" "$((offset_ext4 * 512 + size_ext4))B" set 1 boot on set 1 legacy_boot on
+parted -s --align optimal "${img}.tmp" mklabel gpt mkpart "STBOOT" fat32 "$((offset_vfat * 512))B" "$((offset_vfat * 512 + size_vfat))B" mkpart "STDATA" ext4 "$((offset_ext4 * 512))B" "$((offset_ext4 * 512 + size_ext4))B" set 1 boot on set 1 legacy_boot on
 
 echo ""
 echo "[INFO]: Installing MBR"
-dd bs=440 count=1 conv=notrunc if="${syslinux_cache}/${syslinux_dir}/bios/mbr/gptmbr.bin" of="${img}" status=none
+dd bs=440 count=1 conv=notrunc if="${syslinux_cache}/${syslinux_dir}/bios/mbr/gptmbr.bin" of="${img}.tmp" status=none
+
+mv ${img}{.tmp,}
 
 echo ""
 echo "[INFO]: Image layout:"

--- a/stboot-installation/mbr-bootloader/build_image.sh
+++ b/stboot-installation/mbr-bootloader/build_image.sh
@@ -27,9 +27,7 @@ echo "[INFO]: Using : $(realpath --relative-to="${root}" "${boot_filesystem}")"
 echo "[INFO]: Using : $(realpath --relative-to="${root}" "${data_filesystem}")"
 
 alignment=1048576
-#size_vfat=$((12*(1<<20)))
 size_vfat=$(du -b "${boot_filesystem}" | cut -f1)
-#size_ext4=$((767*(1<<20)))
 size_ext4=$(du -b "${data_filesystem}" | cut -f1)
 offset_vfat=$(( alignment/512 ))
 offset_ext4=$(( (alignment + size_vfat + alignment)/512 ))


### PR DESCRIPTION
Relates to #76.

replace ST_DATA_PARTITION_SZIZE with ST_DATA_PARTITION_EXTRA_SPACE 

ST_DATA_PARTITION_EXTRA_SPACE defines additional storage space of the data
partition in bytes. Suffixes like 'K', 'M', 'G', 'T' are supported. (case insensitive)    
A minimum of 100M is recommended. (corresponds to 100 MiB)