### PR TITLE
Prevent os-package build on network bootmode

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -32,12 +32,9 @@ jobs:
 
       - name: Build default config
         run: make config
-      # create a file in os-package to prevent os autobuild
-      # default github runner does not have kvm access
-      - name: Prevent os-package build
-        run: |
-          mkdir -p out/os-packages
-          touch out/os-packages/.nobuild
+
+      - name: Set boot mode to network
+        run: sed -i 's/ST_BOOT_MODE=local/ST_BOOT_MODE=network/' .config
 
       - name: Build MBR bootloader installation
         run: make mbr-bootloader-installation
@@ -70,12 +67,9 @@ jobs:
 
       - name: Build default config
         run: make config
-      # create a file in os-package to prevent os autobuild
-      # default github runner does not have kvm access
-      - name: Prevent os-package build
-        run: |
-          mkdir -p out/os-packages
-          touch out/os-packages/.nobuild
+
+      - name: Set boot mode to network
+        run: sed -i 's/ST_BOOT_MODE=local/ST_BOOT_MODE=network/' .config
 
       - name: Build MBR bootloader installation
         run: make mbr-bootloader-installation
@@ -109,12 +103,8 @@ jobs:
       - name: Build default config
         run: make config
 
-      # create a file in os-package to prevent os autobuild
-      # default github runner does not have kvm access
-      - name: Prevent os-package build
-        run: |
-          mkdir -p out/os-packages
-          touch out/os-packages/.nobuild
+      - name: Set boot mode to network
+        run: sed -i 's/ST_BOOT_MODE=local/ST_BOOT_MODE=network/' .config
 
       - name: Build MBR bootloader installation
         run: make mbr-bootloader-installation
@@ -148,12 +138,8 @@ jobs:
       - name: Build default config
         run: make config
 
-      # create a file in os-package to prevent os autobuild
-      # default github runner does not have kvm access
-      - name: Prevent os-package build
-        run: |
-          mkdir -p out/os-packages
-          touch out/os-packages/.nobuild
+      - name: Set boot mode to network
+        run: sed -i 's/ST_BOOT_MODE=local/ST_BOOT_MODE=network/' .config
 
       - name: Build MBR bootloader installation
         run: make mbr-bootloader-installation

--- a/stboot-installation/common/Makefile.inc
+++ b/stboot-installation/common/Makefile.inc
@@ -11,9 +11,9 @@ security_config := $(st-out)/security_configuration.json
 os-out_dirs = $(shell find $(os-out) -type d 2>/dev/null)
 os-out_files = $(shell find $(os-out) -type f -name '*' 2>/dev/null)
 
-$(eval $(call CONFIG_DEP,$(data_partition),ST_DATA_PARTITION_EXTRA_SPACE))
-# build and sign example os-package, if directy is empty
-ifeq ($(os-out_files),)
+$(eval $(call CONFIG_DEP,$(data_partition),ST_DATA_PARTITION_EXTRA_SPACE,ST_BOOT_MODE))
+# build and sign example os-package, if bootmode is local and  directy is empty
+ifeq ($(os-out_files)$(filter local,$(ST_BOOT_MODE)),local)
 $(data_partition): % : %.config example-os-package
 else
 $(data_partition): % : %.config $(os-out) $(os-out_dirs) $(os-out_files)


### PR DESCRIPTION
only build and sign example os-package, if ST_BOOT_MODE is local.

Relates to issue #97