### PR TITLE
Fix/cmdline parse

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ endif
 # $3 = file/path (optional)
 #
 define LOG
-printf "[%s] $2 %s\n" "$($1_COLOR)$1$(NORMAL)" "$(FILE_COLOR)$3$(NORMAL)"
+printf '[%s] $2 %s\n' '$($1_COLOR)$1$(NORMAL)' '$(FILE_COLOR)$3$(NORMAL)'
 endef
 
 # Make is silent per default, but 'make V=1' will show all compiler calls.

--- a/contrib/default.config
+++ b/contrib/default.config
@@ -45,8 +45,11 @@ ST_HOST_DNS=""
 # of this initramfs.
 ##############################################################################
 
-# ST_LINUXBOOT_CMDLINE controlls the kernel cmdline of the linuxboot kernel.
+# ST_LINUXBOOT_CMDLINE controls the kernel cmdline of the linuxboot kernel.
 # Flags to stboot can be passed via uroot.uinitargs here as well.
+# ST_LINUXBOOT_CMDLINE uses the same format like the kernel config CONFIG_CMDLINE.
+# for more information see:
+# https://www.kernel.org/doc/html/latest/admin-guide/kernel-parameters.html
 ST_LINUXBOOT_CMDLINE="console=ttyS0,115200 uroot.uinitargs=\"-debug\""
 
 # ST_LINUXBOOT_VARIANT determines the content of the initramfs. Possible values

--- a/contrib/default.config
+++ b/contrib/default.config
@@ -47,7 +47,7 @@ ST_HOST_DNS=""
 
 # ST_LINUXBOOT_CMDLINE controlls the kernel cmdline of the linuxboot kernel.
 # Flags to stboot can be passed via uroot.uinitargs here as well.
-ST_LINUXBOOT_CMDLINE="console=ttyS0,115200 uroot.uinitargs='-debug'"
+ST_LINUXBOOT_CMDLINE="console=ttyS0,115200 uroot.uinitargs=\"-debug\""
 
 # ST_LINUXBOOT_VARIANT determines the content of the initramfs. Possible values
 # are: minimal, debug and full.

--- a/modules/linux.mk
+++ b/modules/linux.mk
@@ -8,6 +8,10 @@ kernel_dev_2 := gregkh@kernel.org
 
 KERNEL_MAKE_FLAGS := ARCH=x86_64
 DEFAULT_CMDLINE="console=ttyS0,115200"
+# escape backslash
+ifneq ($(strip $(wildcard $(DOTCONFIG))),)
+_ST_LINUXBOOT_CMDLINE := $(shell echo '$(ST_LINUXBOOT_CMDLINE)' | sed 's/\\/\\\\/g')
+endif
 
 define KERNEL_MIRROR_PATH
 ifeq ($(findstring x2.6.,x$1),x2.6.)
@@ -128,8 +132,8 @@ ifneq ($(strip $4),)
 	$(call LOG,INFO,Linux/$1: Use configuration file,$(patsubst "%",%,$4));
 	cp $4 $$@.tmp
 ifneq ($(strip $(ST_LINUXBOOT_CMDLINE)),)
-	$(call LOG,WARN,Linux/$1: Override CONFIG_CMDLINE with ST_LINUXBOOT_CMDLINE);
-	sed -ie "s/CONFIG_CMDLINE=.*/CONFIG_CMDLINE=\"$(subst $\",,$(ST_LINUXBOOT_CMDLINE))\"/" $$@.tmp
+	$(call LOG,WARN,Linux/$1: Override CONFIG_CMDLINE with ST_LINUXBOOT_CMDLINE=$(_ST_LINUXBOOT_CMDLINE));
+	sed -ie 's/CONFIG_CMDLINE=.*/CONFIG_CMDLINE=$(_ST_LINUXBOOT_CMDLINE)/g' $$@.tmp
 endif
 	mv $$@.tmp $$@
 endif


### PR DESCRIPTION
ST_LINUXBOOT_CMDLINE should use the same formal like the kernel config CONFIG_CMDLINE.

This PR fixes the config parsing of the particular config and adds comments describing its format.