### PR TITLE
Build Software TPM Emulator to test images with Qemu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -235,6 +235,7 @@ help:
 	@echo  '  ubuntu-20                    - Build reproducible Ubuntu Focal'
 	@echo  '  example-os-package           - Build and Sign an example OS package'
 	@echo  '*** Run in QEMU'
+	@echo  '  swtpm                        - Build Software TPM Emulator'
 	@echo  '  run-mbr-bootloader           - Run MBR bootloader'
 	@echo  '  run-efi-application          - Run EFI application'
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 out ?= out
 out-dirs += $(out)
 cache ?= cache
+tarball_dir := $(cache)/tarball
 common := stboot-installation/common
 scripts := scripts
 stboot-installation := stboot-installation
@@ -188,6 +189,7 @@ endif
 include modules/check.mk
 include modules/go.mk
 include modules/linux.mk
+include modules/swtpm.mk
 
 include operating-system/Makefile.inc
 

--- a/modules/check.mk
+++ b/modules/check.mk
@@ -174,6 +174,20 @@ check_%_lib:
 	  fi; \
 	fi;
 
+check_targets += check_ovmf
+check_ovmf:
+	found=""; \
+	for i in /usr/share/OVMF/OVMF_CODE.fd /usr/share/edk2/ovmf/OVMF_CODE.fd; do \
+	  if [ -f "$$i" ]; then \
+	    found=y; \
+	    $(call LOG,PASS,OVMF binary found:,$$i); \
+	  fi; \
+	done; \
+	if [ "$$found" != "y" ]; then \
+	  $(call LOG,FAIL,OVMF binary not found); \
+	    $(CHECK_EXIT) \
+	fi;
+
 check_targets += check_libc_i386
 check_libc_i386:
 	@$(call LOG,INFO,check runtime library:,libc(i386)) 

--- a/modules/linux.mk
+++ b/modules/linux.mk
@@ -1,4 +1,3 @@
-tarball_dir := $(cache)/tarball
 gpg_dir := $(cache)/gnupg
 gpg_keyring := $(gpg_dir)/keyring.gpg
 kernel_mirror := https://cdn.kernel.org/pub/linux/kernel

--- a/modules/swtpm.mk
+++ b/modules/swtpm.mk
@@ -9,6 +9,8 @@ swtpm_setup_bin := $(swtpm_dir)/bin/swtpm_setup
 libtpms_version := 0.7.7
 swtpm_version := 0.5.2
 
+PYTHONPATH=$(CURDIR)/cache/swtpm/lib/python3/dist-packages
+
 $(tarball_dir)/libtpms-v%.tar.gz:
 	mkdir -p $(tarball_dir)
 	@$(call LOG,INFO,Get,$(notdir $@))

--- a/modules/swtpm.mk
+++ b/modules/swtpm.mk
@@ -63,7 +63,7 @@ $(swtpm_src)/Makefile: $(libtpms_pkg) $(swtpm_src)/.unpack
 $(swtpm_bin): $(swtpm_src)/Makefile
 	mkdir -p $(dir $@)
 	@$(call LOG,INFO,swtpm: Make,swtpm)
-	$(MAKE) -C $(dir $<) install >/dev/null 2>$(dir $<)build.log || \
+	$(MAKE) -C $(dir $<) python-install install >/dev/null 2>$(dir $<)build.log || \
 	($(call LOG,ERROR,swtpm: swtpm build failed. See,$(dir $<)build.log); \
 	exit 1)
 	@$(call LOG,DONE,swtpm:,$(swtpm_bin))

--- a/modules/swtpm.mk
+++ b/modules/swtpm.mk
@@ -1,0 +1,63 @@
+swtpm_dir := $(cache)/swtpm
+swtpm_src := $(swtpm_dir)/src/swtpm
+libtpms_src := $(swtpm_dir)/src/libtpms
+
+libtpms_pkg := $(swtpm_dir)/lib/pkgconfig/libtpms.pc
+swtpm_bin := $(swtpm_dir)/bin/swtpm
+swtpm_setup_bin := $(swtpm_dir)/bin/swtpm_setup
+
+libtpms_version := 0.7.7
+swtpm_version := 0.5.2
+
+$(tarball_dir)/libtpms-v%.tar.gz:
+	mkdir -p $(tarball_dir)
+	@$(call LOG,INFO,Get,$(notdir $@))
+	wget -qO $@ https://github.com/stefanberger/libtpms/archive/refs/tags/v$*.tar.gz
+
+$(tarball_dir)/swtpm-v%.tar.gz:
+	mkdir -p $(tarball_dir)
+	@$(call LOG,INFO,Get,$(notdir $@))
+	wget -qO $@ https://github.com/stefanberger/swtpm/archive/refs/tags/v$*.tar.gz
+
+$(libtpms_src)/.unpack: $(tarball_dir)/libtpms-v$(libtpms_version).tar.gz
+	if [[ -d "$(dir $@)" && ! -f "$@" ]]; then \
+	  rm -rf $(dir $@); \
+	fi
+	mkdir -p $(dir $@)
+	@$(call LOG,INFO,Unpack,$(notdir $<))
+	tar xzf $< --strip 1 -C $(dir $@)
+	touch $@
+
+$(swtpm_src)/.unpack: $(tarball_dir)/swtpm-v$(swtpm_version).tar.gz
+	if [[ -d "$(dir $@)" && ! -f "$@" ]]; then \
+	  rm -rf $(dir $@); \
+	fi
+	mkdir -p $(dir $@)
+	@$(call LOG,INFO,Unpack,$(notdir $<))
+	tar xzf $< --strip 1 -C $(dir $@)
+	touch $@
+
+$(libtpms_src)/Makefile: $(libtpms_src)/.unpack
+	@$(call LOG,INFO,Autogenerate libtpms configuration)
+	cd $(dir $@) && ./autogen.sh --with-tpm2 --with-openssl \
+		--prefix="$(CURDIR)/$(swtpm_dir)" $(OUTREDIRECT)
+
+$(libtpms_pkg): $(libtpms_src)/Makefile
+	@$(call LOG,INFO,Make,libtpms)
+	$(MAKE) -C $(dir $<) install
+	@$(call LOG,DONE,libtpms)
+
+$(swtpm_src)/Makefile: $(libtpms_pkg) $(swtpm_src)/.unpack
+	@$(call LOG,INFO,Autogenerate swtpm configuration)
+	cd $(dir $@) && PKG_CONFIG_PATH="$(CURDIR)/$(dir $<)" \
+	        ./autogen.sh --prefix="$(CURDIR)/$(swtpm_dir)" $(OUTREDIRECT)
+
+$(swtpm_bin): $(swtpm_src)/Makefile
+	mkdir -p $(dir $@)
+	@$(call LOG,INFO,Make,swtpm)
+	$(MAKE) -C $(dir $<) install
+	@$(call LOG,DONE,$(swtpm_bin))
+
+swtpm: $(swtpm_bin)
+
+.PHONY: swtpm

--- a/scripts/start_qemu_efi_application.sh
+++ b/scripts/start_qemu_efi_application.sh
@@ -30,38 +30,8 @@ fi
 
 tpm=$(mktemp -d --suffix='-tpm')
 
-if [ -z "${XDG_CONFIG_HOME:-}" ]; then
-  export XDG_CONFIG_HOME=~/.config
-fi
-
-if [ ! -f "${XDG_CONFIG_HOME}/swtpm-localca.conf" ]; then
-  cat <<EOF > "${XDG_CONFIG_HOME}/swtpm-localca.conf"
-statedir = ${XDG_CONFIG_HOME}/var/lib/swtpm-localca
-signingkey = ${XDG_CONFIG_HOME}/var/lib/swtpm-localca/signkey.pem
-issuercert = ${XDG_CONFIG_HOME}/var/lib/swtpm-localca/issuercert.pem
-certserial = ${XDG_CONFIG_HOME}/var/lib/swtpm-localca/certserial
-EOF
-fi
-
-if [ ! -f "${XDG_CONFIG_HOME}/swtpm-localca.options" ]; then
-  cat <<EOF > "${XDG_CONFIG_HOME}/swtpm-localca.options"
---platform-manufacturer SystemTransparency
---platform-version 2.12
---platform-model QEMU
-EOF
-fi
-
-if [ ! -f "${XDG_CONFIG_HOME}/swtpm_setup.conf" ]; then
-   cat <<EOF > "${XDG_CONFIG_HOME}/swtpm_setup.conf"
-# Program invoked for creating certificates
-create_certs_tool= /usr/share/swtpm/swtpm-localca
-create_certs_tool_config = ${XDG_CONFIG_HOME}/swtpm-localca.conf
-create_certs_tool_options = ${XDG_CONFIG_HOME}/swtpm-localca.options
-EOF
-fi
-
 # Note: TPM1 needs to access tcsd as root..
-swtpm_setup --tpmstate $tpm --tpm2 \
+swtpm_setup --tpmstate $tpm --tpm2 --config ${root}/cache/swtpm/etc/swtpm_setup.conf \
   --create-ek-cert --create-platform-cert --lock-nvram
 
 echo "Starting $tpm"

--- a/scripts/start_qemu_efi_application.sh
+++ b/scripts/start_qemu_efi_application.sh
@@ -26,6 +26,7 @@ done
 
 if [ "$ovmf" == "" ]; then
   echo "ERROR: OVMF not found"
+  exit 1
 fi
 
 tpm=$(mktemp -d --suffix='-tpm')

--- a/scripts/start_qemu_efi_application.sh
+++ b/scripts/start_qemu_efi_application.sh
@@ -38,8 +38,13 @@ swtpm_setup --tpmstate $tpm --tpm2 --config ${root}/cache/swtpm/etc/swtpm_setup.
 echo "Starting $tpm"
 swtpm socket --tpmstate dir=$tpm --tpm2 --ctrl type=unixio,path=/$tpm/swtpm-sock &
 
+args=()
+# use kvm if avaiable
+if [[ -w /dev/kvm ]]; then
+args+=("-enable-kvm")
+fi
+
 qemu-system-x86_64 \
-  -enable-kvm \
   -M q35 \
   -drive if=virtio,file="${image}",format=raw \
   -net user,hostfwd=tcp::2222-:2222 \
@@ -52,6 +57,6 @@ qemu-system-x86_64 \
   -tpmdev emulator,id=tpm0,chardev=chrtpm \
   -device tpm-tis,tpmdev=tpm0 \
   -bios "${ovmf}" \
-  -nographic
+  -nographic "${args[@]}"
 
 rm -r ${tpm/*:?}

--- a/scripts/start_qemu_mbr_bootloader.sh
+++ b/scripts/start_qemu_mbr_bootloader.sh
@@ -17,38 +17,8 @@ image="${root}/out/stboot-installation/mbr-bootloader/stboot_mbr_installation.im
 
 tpm=$(mktemp -d --suffix='-tpm')
 
-if [ -z "${XDG_CONFIG_HOME:-}" ]; then
-  export XDG_CONFIG_HOME=~/.config
-fi
-
-if [ ! -f "${XDG_CONFIG_HOME}/swtpm-localca.conf" ]; then
-  cat <<EOF > "${XDG_CONFIG_HOME}/swtpm-localca.conf"
-statedir = ${XDG_CONFIG_HOME}/var/lib/swtpm-localca
-signingkey = ${XDG_CONFIG_HOME}/var/lib/swtpm-localca/signkey.pem
-issuercert = ${XDG_CONFIG_HOME}/var/lib/swtpm-localca/issuercert.pem
-certserial = ${XDG_CONFIG_HOME}/var/lib/swtpm-localca/certserial
-EOF
-fi
-
-if [ ! -f "${XDG_CONFIG_HOME}/swtpm-localca.options" ]; then
-  cat <<EOF > "${XDG_CONFIG_HOME}/swtpm-localca.options"
---platform-manufacturer SystemTransparency
---platform-version 2.12
---platform-model QEMU
-EOF
-fi
-
-if [ ! -f "${XDG_CONFIG_HOME}/swtpm_setup.conf" ]; then
-   cat <<EOF > "${XDG_CONFIG_HOME}/swtpm_setup.conf"
-# Program invoked for creating certificates
-create_certs_tool= /usr/share/swtpm/swtpm-localca
-create_certs_tool_config = ${XDG_CONFIG_HOME}/swtpm-localca.conf
-create_certs_tool_options = ${XDG_CONFIG_HOME}/swtpm-localca.options
-EOF
-fi
-
 # Note: TPM1 needs to access tcsd as root..
-swtpm_setup --tpmstate $tpm --tpm2 \
+swtpm_setup --tpmstate $tpm --tpm2 --config ${root}/cache/swtpm/etc/swtpm_setup.conf \
   --create-ek-cert --create-platform-cert --lock-nvram
 
 echo "Starting $tpm"

--- a/stboot-installation/efi-application/Makefile.inc
+++ b/stboot-installation/efi-application/Makefile.inc
@@ -22,8 +22,8 @@ $(eval $(call CONFIG_DEP,$(efi_kernel),ST_LINUXBOOT_CMDLINE|ST_EFI_APPLICATION_E
 $(eval $(call KERNEL_TARGET,efi,$(efi_kernel),$(ST_EFI_APPLICATION_EFISTUB_KERNEL_VERSION),$(ST_EFI_APPLICATION_EFISTUB_KERNEL_CONFIG)))
 $(efi_kernel): % : %.config
 
-run-efi-application: $(DOTCONFIG) $(efi_image)
+run-efi-application: $(swtpm_bin) $(DOTCONFIG) $(efi_image)
 	$(call LOG,INFO,Run EFI application image,$(mbr_image))
-	$(scripts)/start_qemu_efi_application.sh
+	PATH=$(dir $<):$${PATH} $(scripts)/start_qemu_efi_application.sh
 
 .PHONY: efi-application-installation run-efi-application

--- a/stboot-installation/mbr-bootloader/Makefile.inc
+++ b/stboot-installation/mbr-bootloader/Makefile.inc
@@ -44,8 +44,8 @@ $(efi32): $(syslinux)
 $(efi64): $(syslinux)
 	cp $(syslinux_efi64) $@
 
-run-mbr-bootloader: $(DOTCONFIG) $(mbr_image)
+run-mbr-bootloader: $(swtpm_bin) $(DOTCONFIG) $(mbr_image)
 	$(call LOG,INFO,Run MBR bootloader image,$(mbr_image))
-	$(scripts)/start_qemu_mbr_bootloader.sh
+	PATH=$(dir $<):$${PATH} $(scripts)/start_qemu_mbr_bootloader.sh
 
 .PHONY: mbr-bootloader-installation run-mbr-bootloader


### PR DESCRIPTION
To test the image in runtime it is necessary to install swtpm.
This PR adds recipes to build swtpm inside the repository instead of listing it as a dependency.

