### PR TITLE
Fix stboot regression and set Go 1.16 as minimum requirement

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -72,10 +72,14 @@ jobs:
     runs-on: ubuntu-20.04
     needs: build-example-os
     steps:
-      - name: Install Go and debos dependencies
+      - name: Install Go 1.17
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.17
+      - name: Install debos dependencies
         run: |
           DEBIAN_FRONTEND=noninteractive sudo apt-get -qq update
-          DEBIAN_FRONTEND=noninteractive sudo apt-get -qqy install golang \
+          DEBIAN_FRONTEND=noninteractive sudo apt-get -qqy install \
           debootstrap systemd-container libglib2.0-dev libostree-dev
 
       - name: Checkout
@@ -417,10 +421,10 @@ jobs:
   build-ubuntu18:
     runs-on: ubuntu-18.04
     steps:
-      - name: Install Go
+      - name: Install Go 1.16
         uses: actions/setup-go@v1
         with:
-          go-version: 1.17
+          go-version: 1.16
 
       - name: Checkout
         uses: actions/checkout@v2

--- a/contrib/default.config
+++ b/contrib/default.config
@@ -17,7 +17,7 @@ ST_UROOT_VERSION=78ac944
 # ST_STBOOT_VERSION defines the branch, tag or commit for stboot and stmanager,
 # using the custom repository: https://github.com/system-transparency/stboot
 #
-ST_STBOOT_VERSION=35b5fcf
+ST_STBOOT_VERSION=6e2173d
 
 
 ##############################################################################

--- a/scripts/deps.sh
+++ b/scripts/deps.sh
@@ -88,7 +88,7 @@ function check_i386_libc {
 
 check_functions+=(check_GO)
 function check_GO {
-   minver=("1" "13")
+   minver=("1" "16")
 
    command -v go >/dev/null 2>&1 || {
       echo >&2 "Go required";


### PR DESCRIPTION
u-root requires Go version >= 1.15:
ref: https://github.com/u-root/u-root#usage
stboot requires Go version >= 1.16:
commit: 35b5fcf
