### PR TITLE
Less strict "file exist"-check.

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -271,7 +271,7 @@ tasks:
       - "test -f {{.INITRAMFS_FILE}}"
     preconditions:
       - *check-config
-      - sh: test -f "{{.ST_SIGNING_ROOT}}"
+      - sh: test -e "{{.ST_SIGNING_ROOT}}"
         msg: "[ERROR] root certificate ({{.ST_SIGNING_ROOT}}) missing\nPlease provide a certificate or run \"task demo:keygen\" to generate example keys"
     vars:
       INITRAMFS_SCRIPT: ./scripts/initramfs.sh


### PR DESCRIPTION
In the taskfile, "test -f" is used, which makes it impossible to use bash process substitution. Change to "test -e" instead.