### PR TITLE
Use correct field for minimum number of signatures.

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ An example security_configuration.json file could look like this:
 ``` json
 {
   "version": 1,
-  "minimal_signatures_match": 2,
+  "min_valid_sigs_required": 2,
   "boot_mode": "local",
   "use_ospkg_cache": false
 }

--- a/scripts/security_config.sh
+++ b/scripts/security_config.sh
@@ -44,7 +44,7 @@ use_ospkg_cache=${ST_USE_PKG_CACHE}
 cat >"${output}" <<EOL
 {
   "version":${version},
-  "minimal_signatures_match": ${num_signatures},
+  "min_valid_sigs_required": ${num_signatures},
   "boot_mode": "${boot_mode}",
   "use_ospkg_cache": ${use_ospkg_cache}
 }


### PR DESCRIPTION
Correct the README and the scripts/security_config.sh to use the
correct security_configuration.json field "min_valid_sigs_required",
instead of "minimal_signatures_match".

Signed-off-by: Björn Töpel <bjorn@mullvad.net>