### PR TITLE
README: Correct the example host_configuration.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,9 +252,10 @@ An example host_configuration.json file could look like this:
     "version":1,
     "network_mode":"static",
     "host_ip":"10.0.2.15/24",
-    "gateway":"10.0.2.2/24",
+    "gateway":"10.0.2.2",
     "dns":"8.8.8.8",
-    "provisioning_urls": ["http://a.server.com","https://b.server.com"],
+    "network_interface":"",
+    "provisioning_urls":["http://a.server.com","https://b.server.com"],
     "identity":"8D4EA31D49AF0EB93FAB198D3FD874B0A2C7C4C4351F28A7967C8D674FE508DC",
     "authentication":"C2F3F516A79F756E7D3128B77077B4A8AEF61E888499FD99AE92E6D4F2E7653C"
 }


### PR DESCRIPTION
Remove the CIDR notation from "gateway", which does not work. Add
"network_interface". Make sure the formatting is consistent.

Signed-off-by: Björn Töpel <bjorn@mullvad.net>