### PR TITLE
Size the vfat partition based on input files.

### DIFF
--- a/scripts/efi_boot_partition.sh
+++ b/scripts/efi_boot_partition.sh
@@ -80,14 +80,21 @@ mkdir -p "$(dirname "${output}")"
 
 ########################################
 
+tot_size=$(du -cb \
+              ${linuxboot_kernel} \
+              ${host_config} | tail -1 | awk '{print $1}')
+
 echo "Creating VFAT filesystems for STBOOT partition:"
-size_vfat=$((12*(1<<20)))
+size_vfat=$((tot_size + (1<<20)))
 
 echo "Using kernel: ${linuxboot_kernel}"
 
 # mkoutput.vfat requires size as an (undefined) block-count; seem to be units of 1k
 if [ -f "${output}.tmp" ]; then rm "${output}.tmp"; fi
-mkfs.vfat -C -n "STBOOT" "${output}.tmp" $((size_vfat >> 10))
+
+vfat_blocks=$((size_vfat >> 10))
+vfat_blocks=$(((($vfat_blocks+32)&~31)))
+mkfs.vfat -C -n "STBOOT" "${output}.tmp" $vfat_blocks
 
 echo "Installing STBOOT.EFI"
 mmd -i "${output}.tmp" ::EFI

--- a/scripts/efi_image.sh
+++ b/scripts/efi_image.sh
@@ -81,9 +81,7 @@ mkdir -p "$(dirname "${output}")"
 ########################################
 
 alignment=1048576
-#size_vfat=$((12*(1<<20)))
 size_vfat=$(du -b "${boot_part}" | cut -f1)
-#size_ext4=$((767*(1<<20)))
 size_ext4=$(du -b "${data_part}" | cut -f1)
 
 offset_vfat=$(( alignment/512 ))


### PR DESCRIPTION
Currently the vfat partion that hosts the LinuxBoot kernel and more,
had a fix size of 12M. This change dynamically adjust the size based
on the actual size of the files.

Signed-off-by: Björn Töpel <bjorn@mullvad.net>