### PR TITLE
Remove .envrc requirement

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -17,6 +17,10 @@ jobs:
         uses: actions/setup-go@v1
         with:
           go-version: 1.17
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+
       - name: Install dependencies
         run: |
           DEBIAN_FRONTEND=noninteractive sudo apt-get -qq update
@@ -28,17 +32,14 @@ jobs:
 
       - name: Install dependencies
         run: |
-          . .envrc
           task deps:install
 
       - name: Build default config
         run: |
-          . .envrc
           task config
 
       - name: Generate example signing keys
         run: |
-          . .envrc
           task demo:keygen
 
       - name: Download example OS
@@ -50,7 +51,6 @@ jobs:
 
       - name: Generate and sign OS Package
         run: |
-          . .envrc
           task demo:ospkg
 
       - name: Upload example OS Package
@@ -62,7 +62,6 @@ jobs:
 
       - name: Build network mode images
         run: |
-          . .envrc
           task images
 
       - name: Upload network mode disk installations
@@ -86,7 +85,6 @@ jobs:
 
       - name: Build local mode disk image
         run: |
-          . .envrc
           task disk
 
       - name: Upload local mode disk installation
@@ -106,12 +104,14 @@ jobs:
           DEBIAN_FRONTEND=noninteractive sudo apt-get -qq update
           DEBIAN_FRONTEND=noninteractive sudo apt-get -qqy install qemu-system-x86
 
+      - name: Install Task
+        uses: arduino/setup-task@v1
+
       - name: Checkout
         uses: actions/checkout@v2
 
       - name: Build default config
         run: |
-          . .envrc
           task config
 
       - name: Set boot mode to network
@@ -133,12 +133,10 @@ jobs:
 
       - name: Start http server to serve OS Package
         run: |
-          . .envrc
           task demo:server &
 
       - name: Boot stboot disk in network mode using QEMU
         run: |
-          . .envrc
           .github/workflows/scripts/test-qemu.sh disk
 
   run-iso-network:
@@ -151,12 +149,14 @@ jobs:
           DEBIAN_FRONTEND=noninteractive sudo apt-get -qq update
           DEBIAN_FRONTEND=noninteractive sudo apt-get -qqy install qemu-system-x86
 
+      - name: Install Task
+        uses: arduino/setup-task@v1
+
       - name: Checkout
         uses: actions/checkout@v2
 
       - name: Build default config
         run: |
-          . .envrc
           task config
 
       - name: Set boot mode to network
@@ -178,12 +178,10 @@ jobs:
 
       - name: Start http server to serve OS Package
         run: |
-          . .envrc
           task demo:server &
 
       - name: Boot stboot iso in network mode using QEMU
         run: |
-          . .envrc
           .github/workflows/scripts/test-qemu.sh iso
 
   run-disk-local:
@@ -196,12 +194,14 @@ jobs:
           DEBIAN_FRONTEND=noninteractive sudo apt-get -qq update
           DEBIAN_FRONTEND=noninteractive sudo apt-get -qqy install qemu-system-x86
 
+      - name: Install Task
+        uses: arduino/setup-task@v1
+
       - name: Checkout
         uses: actions/checkout@v2
 
       - name: Build default config
         run: |
-          . .envrc
           task config
 
       - name: Set boot mode to local
@@ -217,7 +217,6 @@ jobs:
 
       - name: Boot stboot disk in local mode using QEMU
         run: |
-          . .envrc
           .github/workflows/scripts/test-qemu.sh disk
 
   build-ubuntu18:
@@ -228,25 +227,24 @@ jobs:
         with:
           go-version: 1.17
 
+      - name: Install Task
+        uses: arduino/setup-task@v1
+
       - name: Checkout
         uses: actions/checkout@v2
 
       - name: Install dependencies
         run: |
-          . .envrc
           task deps:install
 
       - name: Build default config
         run: |
-          . .envrc
           task config
 
       - name: Generate example signing keys
         run: |
-          . .envrc
           task demo:keygen
 
       - name: Build stboot image without ospkg
         run: |
-          . .envrc
           task images

--- a/README.md
+++ b/README.md
@@ -57,18 +57,18 @@ task clean-all
 
 ## Environment
 
-The System Transparency Repository provides a `.envrc` file to load the build environment. It installs the latest version of [Task](https://taskfile.dev) and configures a separate Go environment to prevent any conflicts. To load and unload the environment depending on the current directory, it is recommended to use [direnv](https://direnv.net/). Go to [Basic Installation](https://direnv.net/#basic-installation) to see how to properly setup direnv your shell.
+The System Transparency Repository provides a `setup.env` file to load the build environment. It installs the latest version of [Task](https://taskfile.dev) and configures a separate GOPATH to prevent any conflicts. To load and unload the environment depending on the current directory, it is recommended to use [direnv](https://direnv.net/). Go to [Basic Installation](https://direnv.net/#basic-installation) to see how to properly setup direnv for your shell.
 After restarting your shell, you can enable direnv for the repository:
 
 ```bash
-cd system-transparency
+echo "source setup.env" > .envrc
 direnv allow
 ```
 
 As an alternative, you can load the environment directly without direnv:
 
 ```bash
-source .envrc
+source setup.env
 ```
 
 However, this is only recommended on CI workflows since it makes the environment changes persistent in your current shell session.

--- a/setup.env
+++ b/setup.env
@@ -1,13 +1,12 @@
 TASKBIN="${PWD}/bin"
 GOPATH="${PWD}/cache/go"
 GOBIN="${GOPATH}/bin"
-TASK="${TASKBIN}/task"
 
 # install task
-[[ -x "${TASK}" ]] || sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -b "${TASKBIN}"
+[[ -x "${TASKBIN}/task" ]] || sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -b "${TASKBIN}"
 
 # export custom go environment
-export GOPATH="${PWD}/cache/go"
+export GOPATH
 
 # extend PATH
 [[ $PATH != *${TASKBIN}* ]] && export PATH=${TASKBIN}:$PATH

--- a/tasks/demo.yml
+++ b/tasks/demo.yml
@@ -13,7 +13,7 @@ tasks:
       - cmd: mkdir -p {{.DEMO_KEY_DIR}}
         silent: true
       - cmd: >
-             CMD="stmgr keygen certificate -isCA
+             CMD="{{.GOBIN}}/stmgr keygen certificate -isCA
              -certOut="{{.DEMO_KEY_DIR}}/root.cert"
              -keyOut="{{.DEMO_KEY_DIR}}/root.key"";
              echo $CMD;
@@ -21,7 +21,7 @@ tasks:
         silent: true
       - cmd: >
              for I in {1..{{.ST_NUM_SIGNATURES}}}; do
-             CMD="stmgr keygen certificate -rootCert={{.DEMO_KEY_DIR}}/root.cert
+             CMD="{{.GOBIN}}/stmgr keygen certificate -rootCert={{.DEMO_KEY_DIR}}/root.cert
              -rootKey={{.DEMO_KEY_DIR}}/root.key
              -certOut={{.DEMO_KEY_DIR}}/signing-key-${I}.cert
              -keyOut={{.DEMO_KEY_DIR}}/signing-key-${I}.key";
@@ -52,8 +52,8 @@ tasks:
       - "{{.ST_LOCAL_OSPKG_DIR}}/{{.EXAMPLE_OSPKG}}"
     cmds:
       - "mkdir -p {{.ST_LOCAL_OSPKG_DIR}}"
-      - "stmgr ospkg create -out '{{.ST_LOCAL_OSPKG_DIR}}/{{.EXAMPLE_OSPKG}}' -label='{{.LABEL}}' -kernel={{.KERNEL}} -initramfs={{.INITRD}} -cmdline='{{.CMDLINE}}' -url=http://10.0.2.2:8080/os-pkg-example-ubuntu20.zip"
-      - "for i in {1..{{.ST_NUM_SIGNATURES}}}; do stmgr ospkg sign -key={{.SIGNKEYS_DIR}}/signing-key-$i.key -cert={{.SIGNKEYS_DIR}}/signing-key-$i.cert -ospkg {{.ST_LOCAL_OSPKG_DIR}}/{{.EXAMPLE_OSPKG}}; done"
+      - "{{.GOBIN}}/stmgr ospkg create -out '{{.ST_LOCAL_OSPKG_DIR}}/{{.EXAMPLE_OSPKG}}' -label='{{.LABEL}}' -kernel={{.KERNEL}} -initramfs={{.INITRD}} -cmdline='{{.CMDLINE}}' -url=http://10.0.2.2:8080/os-pkg-example-ubuntu20.zip"
+      - "for i in {1..{{.ST_NUM_SIGNATURES}}}; do {{.GOBIN}}/stmgr ospkg sign -key={{.SIGNKEYS_DIR}}/signing-key-$i.key -cert={{.SIGNKEYS_DIR}}/signing-key-$i.cert -ospkg {{.ST_LOCAL_OSPKG_DIR}}/{{.EXAMPLE_OSPKG}}; done"
       - "echo {{.EXAMPLE_OSPKG}} > {{.ST_LOCAL_OSPKG_DIR}}/boot_order"
     status:
       - "test -f {{.ST_LOCAL_OSPKG_DIR}}/{{.EXAMPLE_OSPKG}}"

--- a/tasks/go.yml
+++ b/tasks/go.yml
@@ -6,6 +6,9 @@ vars:
   CPU_REPO: github.com/u-root/cpu
   CPU_VERSION: 4e8a556
   GOBIN: cache/go/bin
+  GOPATH:
+    sh: echo "$PWD/cache/go"
+  GOPREFIX: GOPATH={{.GOPATH}}
 
 tasks:
 
@@ -14,7 +17,7 @@ tasks:
   #      conflicting git commands may be caused.
   get:
     cmds:
-      - "go get -d {{.REPO}}/..."
+      - "{{.GOPREFIX}} go get -d {{.REPO}}/..."
     env:
       GO111MODULE: off
     label: "get {{.REPO}}"
@@ -53,7 +56,7 @@ tasks:
 
   install:
     cmds:
-      - 'go install {{.PACKAGE}}@{{.VERSION}}'
+      - '{{.GOPREFIX}} go install {{.PACKAGE}}@{{.VERSION}}'
       # create version file
       - cmd: 'echo "{{.VERSION}}" > {{.GOBIN}}/.{{.NAME}}'
         silent: true
@@ -120,7 +123,7 @@ tasks:
 
   debos:
     cmds:
-      - 'go get github.com/go-debos/debos/cmd/debos'
+      - '{{.GOPREFIX}} go get github.com/go-debos/debos/cmd/debos'
     deps:
       # libglib2.0-dev
       - task: :deps:check-pkg

--- a/tasks/stboot.yml
+++ b/tasks/stboot.yml
@@ -27,7 +27,7 @@ tasks:
     method: timestamp
     cmds:
       - >
-        u-root -build=bb -uinitcmd=stboot -defaultsh="" -o {{.OUTPUT}}.tmp
+        {{.GOPREFIX}} {{.GOBIN}}/u-root -build=bb -uinitcmd=stboot -defaultsh="" -o {{.OUTPUT}}.tmp
         {{.FILES_ARGS}} {{.PKGS_ARGS}}
       - mv {{.OUTPUT}}.tmp {{.OUTPUT}}
     env:


### PR DESCRIPTION
Move .envrc to setup.env and make it optional.
It is not required to source the environment file to build
all task targets.

Signed-off-by: Marcello Sylvester Bauer <sylv@sylv.io>