### PR TITLE
task: Introduce fetch target

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -62,6 +62,13 @@ tasks:
       - task -l
     interactive: true
 
+  fetch:
+    desc: Fetch dependencies which require network access
+    deps:
+      - check-config
+      - go:all
+      - linux:fetch
+
   images:
     desc: Build stboot images
     deps:

--- a/tasks/go.yml
+++ b/tasks/go.yml
@@ -83,6 +83,9 @@ tasks:
       - task
       - u-root
       - stmgr
+      - checkout-cpu
+      - checkout-uroot
+      - checkout-stboot
 
   update:
     cmds:


### PR DESCRIPTION
Add target to fetch build dependencies. In this way it is possible to
build installation targets without network access.

Signed-off-by: Marcello Sylvester Bauer <sylv@sylv.io>