### PR TITLE
Remove task go:task target

### DIFF
--- a/tasks/go.yml
+++ b/tasks/go.yml
@@ -95,14 +95,6 @@ tasks:
       - task: all
     run: once
 
-  task:
-    cmds:
-      - task: install
-        vars:
-          NAME: task
-          PACKAGE: github.com/go-task/task/v3/cmd/task
-    run: once
-
   u-root:
     cmds:
       - task: install


### PR DESCRIPTION
Do not build task binary to prevent "command not found" error after
calling clean-all. Do only rely on the task binary bootstrapped by
setup.env.

Signed-off-by: Marcello Sylvester Bauer <sylv@sylv.io>