### PR TITLE
pack.sh: set pipefail to catch errors

### DIFF
--- a/contrib/debos/scripts/pack.sh
+++ b/contrib/debos/scripts/pack.sh
@@ -2,6 +2,7 @@
 
 set -o errexit
 set -o nounset
+set -o pipefail
 # set -o xtrace
 
 kernel_out="$ARTIFACTDIR/$1.vmlinuz"


### PR DESCRIPTION
Issues like a missing `cpio` binary would go unnoticed in the pipeline.
Lets make theme explicit.

Signed-off-by: Morten Linderud <morten.linderud@mullvad.net>