### PR TITLE
bump u-root to v0.10.0

### DIFF
--- a/tasks/go.yml
+++ b/tasks/go.yml
@@ -2,7 +2,7 @@ version: '3'
 
 vars:
   UROOT_REPO: github.com/u-root/u-root
-  UROOT_DEFAULT_VERSION: 78ac944
+  UROOT_DEFAULT_VERSION: v0.10.0
   STBOOT_REPO: github.com/system-transparency/stboot
   STBOOT_DEFAULT_VERSION: 4b208b7
   STMGR_REPO: github.com/system-transparency/stmgr

--- a/tasks/go.yml
+++ b/tasks/go.yml
@@ -4,7 +4,7 @@ vars:
   UROOT_REPO: github.com/u-root/u-root
   UROOT_DEFAULT_VERSION: v0.10.0
   STBOOT_REPO: github.com/system-transparency/stboot
-  STBOOT_DEFAULT_VERSION: 4b208b7
+  STBOOT_DEFAULT_VERSION: 96c2c50
   STMGR_REPO: github.com/system-transparency/stmgr
   STMGR_DEFAULT_VERSION: 1c1394b
   CPU_REPO: github.com/u-root/cpu

--- a/tasks/go.yml
+++ b/tasks/go.yml
@@ -6,7 +6,7 @@ vars:
   STBOOT_REPO: github.com/system-transparency/stboot
   STBOOT_DEFAULT_VERSION: 96c2c50
   STMGR_REPO: github.com/system-transparency/stmgr
-  STMGR_DEFAULT_VERSION: 1c1394b
+  STMGR_DEFAULT_VERSION: f1631dd
   CPU_REPO: github.com/u-root/cpu
   CPU_DEFAULT_VERSION: a901912
   GOBIN: cache/go/bin

--- a/tasks/stboot.yml
+++ b/tasks/stboot.yml
@@ -181,7 +181,11 @@ tasks:
         silent: true
       - |-
         cat > "{{.PROVISIONING_INITRC}}" <<EOL
-        mount -t efivarfs none /sys/firmware/efi/efivars || true
+        try {
+          mount -t efivarfs none /sys/firmware/efi/efivars
+        } except e {
+          echo "failed to mount efivarfs, probably already mounted"
+        }
         stmgr provision hostconfig {{.ST_PROVISO_STMGR_ARGS}}
         shutdown
         EOL

--- a/tasks/stboot.yml
+++ b/tasks/stboot.yml
@@ -181,7 +181,7 @@ tasks:
         silent: true
       - |-
         cat > "{{.PROVISIONING_INITRC}}" <<EOL
-        mount -t efivarfs none /sys/firmware/efi/efivars
+        mount -t efivarfs none /sys/firmware/efi/efivars || true
         stmgr provision hostconfig {{.ST_PROVISO_STMGR_ARGS}}
         shutdown
         EOL

--- a/tasks/stboot.yml
+++ b/tasks/stboot.yml
@@ -29,6 +29,7 @@ tasks:
     cmds:
       - >
         {{.GOPREFIX}} {{.GOBIN}}/u-root -build=bb -uinitcmd="stboot {{.HOST_CONFIG_ARG}} {{.ST_STBOOT_ARGS}}" -defaultsh=""
+        -uroot-source ./cache/go/src/{{.UROOT_REPO}}
         -o {{.OUTPUT}}.tmp {{.FILES_ARGS}} {{.PKGS_ARGS}}
       - mv {{.OUTPUT}}.tmp {{.OUTPUT}}
     env:
@@ -209,6 +210,7 @@ tasks:
         silent: true
       - >
         {{.GOPREFIX}} {{.GOBIN}}/u-root -build=bb
+        -uroot-source ./cache/go/src/{{.UROOT_REPO}}
         -o {{.INITRAMFS}} {{.FILES_ARGS}} {{.PKGS_ARGS}}
       - gzip -kf {{.INITRAMFS}}
     env:


### PR DESCRIPTION
This unbreaks building with go versions higher than 1.15 or so.

The `-uroot-source` command line argument is needed in modern u-root, see u-root/README.