### PR TITLE
go: Implement support for GO_LDFLAGS

### DIFF
--- a/tasks/go.yml
+++ b/tasks/go.yml
@@ -60,7 +60,7 @@ tasks:
 
   install:
     cmds:
-      - '{{.GOPREFIX}} go install {{.PACKAGE}}@{{.VERSION}}'
+      - '{{.GOPREFIX}} go install -ldflags "{{.GO_LDFLAGS}}" {{.PACKAGE}}@{{.VERSION}}'
       # create version file
       - cmd: 'echo "{{.VERSION}}" > {{.GOBIN}}/.{{.NAME}}'
         silent: true
@@ -77,6 +77,7 @@ tasks:
       - 'grep -q {{.VERSION}} {{.GOBIN}}/.{{.NAME}}'
     vars:
       VERSION: '{{default "latest" .VERSION}}'
+      GO_LDFLAGS: '{{default "" .GO_LDFLAGS}}'
 
   all:
     deps:


### PR DESCRIPTION
Allows us to supply LDFLAGS into the go install command. This is practical to build binaries with embedded versions or other variables.

Signed-off-by: Morten Linderud <morten.linderud@mullvad.net>