### PR TITLE
proviso/rc.elv: don't error on failing efivarfs mount, report the error

### DIFF
--- a/tasks/stboot.yml
+++ b/tasks/stboot.yml
@@ -180,7 +180,11 @@ tasks:
         silent: true
       - |-
         cat > "{{.PROVISIONING_INITRC}}" <<EOL
-        mount -t efivarfs none /sys/firmware/efi/efivars
+        try {
+          mount -t efivarfs none /sys/firmware/efi/efivars
+        } except e {
+          echo "failed to mount efivarfs, probably aleady mounted"
+        }
         stmgr provision hostconfig {{.ST_PROVISO_STMGR_ARGS}}
         shutdown
         EOL


### PR DESCRIPTION
Signed-off-by: Morten Linderud <morten.linderud@mullvad.net>