### PR TITLE
Test using go1.19.1 on ubuntu-20.04

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -13,10 +13,10 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
-      - name: Install Go 1.17
+      - name: Install Go 1.19.1
         uses: actions/setup-go@v1
         with:
-          go-version: 1.17
+          go-version: 1.19.1
 
       - name: Install Task
         uses: arduino/setup-task@v1


### PR DESCRIPTION
1.19.1 was picked because Debian bullseye-backports have that version.

Keeping the ubuntu-18.04 on go1.17 to catch (some) breakage on 1.17.